### PR TITLE
Add robust installation tool for Jexpresso dependencies

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -1,0 +1,243 @@
+# Jexpresso Installation Guide
+
+This guide provides detailed instructions for installing Jexpresso and its dependencies with the correct package versions.
+
+## Prerequisites
+
+- **Julia 1.11.2 or higher** (required)
+- **Git** (for cloning the repository)
+- **MPI** (for parallel computing support)
+
+## Quick Start
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/smarras79/Jexpresso.git
+cd Jexpresso
+```
+
+### 2. Checkout the yt/wallmodel Branch
+
+The `yt/wallmodel` branch is the most developed and will soon replace master:
+
+```bash
+git checkout yt/wallmodel
+```
+
+### 3. Run the Installation Script
+
+We provide a robust installation script that automatically installs all dependencies with the correct versions:
+
+```bash
+julia install_dependencies.jl
+```
+
+The script will:
+- ✓ Check your Julia version
+- ✓ Activate the project environment
+- ✓ Create a backup of your current Manifest.toml
+- ✓ Install all required packages with specific versions
+- ✓ Resolve dependencies
+- ✓ Verify installations
+- ✓ Precompile packages
+
+### 4. Verify Installation
+
+After installation, you can verify that everything is correctly installed by checking the package versions:
+
+```julia
+using Pkg
+Pkg.status()
+```
+
+## Required Package Versions
+
+The following packages must be installed with specific versions to ensure compatibility:
+
+| Package | Version |
+|---------|---------|
+| MPI | 0.20.22 |
+| MPIPreferences | 0.1.11 |
+| PackageCompiler | 2.2.1 |
+| Thermodynamics | 0.12.7 |
+| PrettyTables | 2.4.0 |
+| Crayons | 4.1.1 |
+| UnicodePlots | 3.7.2 |
+| Gridap | 0.18.12 |
+| GridapDistributed | 0.4.7 |
+| GridapGmsh | 0.7.2 |
+| GridapP4est | 0.3.11 |
+
+## Troubleshooting
+
+### Installation Script Fails
+
+If the installation script fails, try the following:
+
+1. **Update Julia**: Ensure you have Julia 1.11.2 or higher
+   ```bash
+   julia --version
+   ```
+
+2. **Manual Installation**: Install packages manually if the script fails:
+   ```julia
+   using Pkg
+   Pkg.activate(".")
+   Pkg.add(name="MPI", version="0.20.22")
+   Pkg.add(name="MPIPreferences", version="0.1.11")
+   # ... continue for other packages
+   ```
+
+3. **Clear Package Cache**: If you encounter persistent errors, try clearing the package cache:
+   ```julia
+   using Pkg
+   Pkg.gc()
+   ```
+
+4. **Remove Manifest.toml**: If there are conflicts, remove the Manifest.toml and run the installation script again:
+   ```bash
+   rm Manifest.toml
+   julia install_dependencies.jl
+   ```
+
+### Version Conflicts
+
+If you experience version conflicts:
+
+1. The installation script will attempt to pin packages to the correct versions automatically
+2. If automatic pinning fails, you can manually pin packages:
+   ```julia
+   using Pkg
+   Pkg.pin(name="PackageName", version="x.y.z")
+   ```
+
+### Precompilation Errors
+
+If precompilation fails:
+
+1. Try precompiling individual packages:
+   ```julia
+   using Pkg
+   Pkg.precompile("PackageName")
+   ```
+
+2. Some packages may have compatibility issues with your system. Check the error messages for specific guidance.
+
+## Advanced Installation
+
+### Installing from Scratch
+
+If you want a completely fresh installation:
+
+```bash
+# Remove existing Julia environment files
+rm -f Manifest.toml
+
+# Run installation script
+julia install_dependencies.jl
+```
+
+### Installing on HPC Systems
+
+For HPC systems with module systems:
+
+```bash
+# Load Julia module
+module load julia/1.11.2
+
+# Set Julia depot path (optional, for custom package location)
+export JULIA_DEPOT_PATH=/path/to/your/depot
+
+# Run installation
+julia install_dependencies.jl
+```
+
+### Installing with Different MPI Implementations
+
+If you need to use a specific MPI implementation:
+
+```julia
+using MPIPreferences
+MPIPreferences.use_system_binary()  # Use system MPI
+# or
+MPIPreferences.use_jll_binary()     # Use Julia-provided MPI
+```
+
+Then run the installation script.
+
+## Verification
+
+After installation, verify that Jexpresso works correctly:
+
+```bash
+# Run a simple test case
+julia --project=. test/run_tests.jl
+```
+
+## Backup and Recovery
+
+The installation script automatically creates a backup of your `Manifest.toml` file as `Manifest.toml.backup`. If something goes wrong, you can restore it:
+
+```bash
+mv Manifest.toml.backup Manifest.toml
+```
+
+## Getting Help
+
+If you encounter issues not covered in this guide:
+
+1. Check the [Jexpresso documentation](https://smarras79.github.io/Jexpresso/dev/)
+2. Contact the developers:
+   - Simone Marras: smarras@njit.edu
+   - Yassine Tissaoui: tissaoui@wisc.edu
+   - Hang Wang: hang.wang@njit.edu
+3. Open an issue on GitHub: https://github.com/smarras79/Jexpresso/issues
+
+## Updating Dependencies
+
+If package versions need to be updated in the future:
+
+1. Edit the `REQUIRED_PACKAGES` dictionary in `install_dependencies.jl`
+2. Run the installation script again
+3. Test thoroughly before committing changes
+
+## Performance Tips
+
+After installation:
+
+1. **Precompile packages**: This is done automatically by the script, but can be repeated:
+   ```julia
+   using Pkg
+   Pkg.precompile()
+   ```
+
+2. **Use PackageCompiler**: For frequently-run scripts, consider using PackageCompiler to create a custom system image:
+   ```julia
+   using PackageCompiler
+   create_sysimage(["Jexpresso"], sysimage_path="jexpresso.so")
+   ```
+
+3. **Enable threading**: Run Julia with multiple threads for better performance:
+   ```bash
+   julia --project=. --threads=auto
+   ```
+
+## License
+
+Jexpresso is open-source software. Please see the LICENSE file for details.
+
+## Citation
+
+If you use Jexpresso, please cite:
+
+```bibtex
+@article{tissaoui2024,
+  author = {Y. Tissaoui and J. F. Kelly and S. Marras},
+  title = {Efficient Spectral Element Method for the Euler Equations on Unbounded Domains},
+  volume = {487},
+  pages = {129080},
+  year = {2024},
+  journal = {App. Math. Comput.},
+}
+```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,86 @@
+# Jexpresso Quick Start Guide
+
+Get up and running with Jexpresso in minutes!
+
+## Installation (One Command)
+
+```bash
+./install.sh
+```
+
+or
+
+```bash
+julia install_dependencies.jl
+```
+
+That's it! The installation script will:
+- ✓ Check your Julia version
+- ✓ Install all dependencies with correct versions
+- ✓ Verify the installation
+- ✓ Precompile everything
+
+## What Gets Installed
+
+The following packages will be installed with specific versions for maximum compatibility:
+
+- MPI 0.20.22
+- MPIPreferences 0.1.11
+- PackageCompiler 2.2.1
+- Thermodynamics 0.12.7
+- PrettyTables 2.4.0
+- Crayons 4.1.1
+- UnicodePlots 3.7.2
+- Gridap v0.18.12
+- GridapDistributed v0.4.7
+- GridapGmsh v0.7.2
+- GridapP4est v0.3.11
+
+## Running Your First Simulation
+
+After installation:
+
+```bash
+# Activate the project
+julia --project=.
+
+# Run a test case
+julia> include("examples/your_example.jl")
+```
+
+## Common Issues
+
+### "Julia version too old"
+**Solution:** Install Julia 1.11.2 or higher from https://julialang.org/downloads/
+
+### "Package version conflict"
+**Solution:** The installer automatically handles this, but if issues persist:
+```bash
+rm Manifest.toml
+./install.sh
+```
+
+### "Precompilation failed"
+**Solution:** Usually not critical. Try:
+```julia
+using Pkg
+Pkg.precompile()
+```
+
+## Need Help?
+
+- 📖 Full documentation: [INSTALLATION.md](INSTALLATION.md)
+- 🌐 Online docs: https://smarras79.github.io/Jexpresso/dev/
+- 📧 Email: smarras@njit.edu
+
+## Next Steps
+
+1. ✅ Installation complete? Great!
+2. 📚 Read the [documentation](https://smarras79.github.io/Jexpresso/dev/)
+3. 🚀 Try the example cases in `examples/`
+4. 🎓 Learn about spectral element methods
+5. 🤝 Join the Jexpresso community!
+
+---
+
+**Pro Tip:** For faster startup times on subsequent runs, consider using PackageCompiler to create a custom system image. See INSTALLATION.md for details.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Jexpresso Installation Wrapper Script
+# This script provides a convenient way to run the Julia installation script
+
+set -e  # Exit on error
+
+# Color codes for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "==============================================="
+echo "  Jexpresso Dependency Installer"
+echo "==============================================="
+echo ""
+
+# Check if Julia is installed
+if ! command -v julia &> /dev/null; then
+    echo -e "${RED}Error: Julia is not installed or not in PATH${NC}"
+    echo "Please install Julia 1.11.2 or higher from https://julialang.org/downloads/"
+    exit 1
+fi
+
+# Check Julia version
+echo "Checking Julia version..."
+JULIA_VERSION=$(julia --version | grep -oP '\d+\.\d+\.\d+' | head -1)
+echo "Found Julia version: $JULIA_VERSION"
+
+# Compare versions (basic check)
+REQUIRED_MAJOR=1
+REQUIRED_MINOR=11
+REQUIRED_PATCH=2
+
+CURRENT_MAJOR=$(echo $JULIA_VERSION | cut -d. -f1)
+CURRENT_MINOR=$(echo $JULIA_VERSION | cut -d. -f2)
+CURRENT_PATCH=$(echo $JULIA_VERSION | cut -d. -f3)
+
+if [ "$CURRENT_MAJOR" -lt "$REQUIRED_MAJOR" ] || \
+   ([ "$CURRENT_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CURRENT_MINOR" -lt "$REQUIRED_MINOR" ]) || \
+   ([ "$CURRENT_MAJOR" -eq "$REQUIRED_MAJOR" ] && [ "$CURRENT_MINOR" -eq "$REQUIRED_MINOR" ] && [ "$CURRENT_PATCH" -lt "$REQUIRED_PATCH" ]); then
+    echo -e "${YELLOW}Warning: Julia version $JULIA_VERSION is older than recommended version 1.11.2${NC}"
+    echo "Consider upgrading Julia for best compatibility"
+    read -p "Continue anyway? (y/N) " -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+        exit 1
+    fi
+fi
+
+# Run the Julia installation script
+echo ""
+echo "Running Julia dependency installation script..."
+echo ""
+
+julia install_dependencies.jl
+EXIT_CODE=$?
+
+echo ""
+if [ $EXIT_CODE -eq 0 ]; then
+    echo -e "${GREEN}Installation completed successfully!${NC}"
+    echo ""
+    echo "Next steps:"
+    echo "  1. To use Jexpresso, run: julia --project=."
+    echo "  2. See INSTALLATION.md for detailed usage instructions"
+    echo "  3. Check documentation at: https://smarras79.github.io/Jexpresso/dev/"
+else
+    echo -e "${RED}Installation failed with errors${NC}"
+    echo "Please check the error messages above and see INSTALLATION.md for troubleshooting"
+    exit $EXIT_CODE
+fi

--- a/install_dependencies.jl
+++ b/install_dependencies.jl
@@ -1,0 +1,417 @@
+#!/usr/bin/env julia
+"""
+Jexpresso Dependency Installer
+================================
+
+This script ensures that all required dependencies for Jexpresso are installed
+with the correct versions. It handles installation errors and provides clear
+feedback about the installation process.
+
+Usage:
+    julia install_dependencies.jl
+
+Or make it executable:
+    chmod +x install_dependencies.jl
+    ./install_dependencies.jl
+"""
+
+using Pkg
+
+# ANSI color codes for terminal output
+const COLOR_GREEN = "\033[32m"
+const COLOR_RED = "\033[31m"
+const COLOR_YELLOW = "\033[33m"
+const COLOR_BLUE = "\033[34m"
+const COLOR_CYAN = "\033[36m"
+const COLOR_RESET = "\033[0m"
+
+# Package versions required for Jexpresso
+const REQUIRED_PACKAGES = Dict(
+    "MPI" => "0.20.22",
+    "MPIPreferences" => "0.1.11",
+    "PackageCompiler" => "2.2.1",
+    "Thermodynamics" => "0.12.7",
+    "PrettyTables" => "2.4.0",
+    "Crayons" => "4.1.1",
+    "UnicodePlots" => "3.7.2",
+    "Gridap" => "0.18.12",
+    "GridapDistributed" => "0.4.7",
+    "GridapGmsh" => "0.7.2",
+    "GridapP4est" => "0.3.11"
+)
+
+const MIN_JULIA_VERSION = v"1.11.2"
+
+"""
+    print_header()
+
+Print a stylized header for the installation script.
+"""
+function print_header()
+    println("\n" * "="^70)
+    println("$(COLOR_CYAN)Jexpresso Dependency Installer$(COLOR_RESET)")
+    println("="^70 * "\n")
+end
+
+"""
+    print_section(title::String)
+
+Print a section header.
+"""
+function print_section(title::String)
+    println("\n$(COLOR_BLUE)▶ $title$(COLOR_RESET)")
+    println("-"^70)
+end
+
+"""
+    print_success(message::String)
+
+Print a success message in green.
+"""
+function print_success(message::String)
+    println("$(COLOR_GREEN)✓ $message$(COLOR_RESET)")
+end
+
+"""
+    print_error(message::String)
+
+Print an error message in red.
+"""
+function print_error(message::String)
+    println("$(COLOR_RED)✗ $message$(COLOR_RESET)")
+end
+
+"""
+    print_warning(message::String)
+
+Print a warning message in yellow.
+"""
+function print_warning(message::String)
+    println("$(COLOR_YELLOW)⚠ $message$(COLOR_RESET)")
+end
+
+"""
+    print_info(message::String)
+
+Print an informational message.
+"""
+function print_info(message::String)
+    println("  $message")
+end
+
+"""
+    check_julia_version()
+
+Verify that the Julia version meets the minimum requirements.
+"""
+function check_julia_version()
+    print_section("Checking Julia Version")
+
+    current_version = VERSION
+    print_info("Current Julia version: $current_version")
+    print_info("Minimum required version: $MIN_JULIA_VERSION")
+
+    if current_version >= MIN_JULIA_VERSION
+        print_success("Julia version is compatible")
+        return true
+    else
+        print_error("Julia version is too old")
+        print_warning("Please upgrade to Julia $MIN_JULIA_VERSION or higher")
+        return false
+    end
+end
+
+"""
+    get_installed_version(package_name::String)
+
+Get the currently installed version of a package, or nothing if not installed.
+"""
+function get_installed_version(package_name::String)
+    try
+        deps = Pkg.dependencies()
+        for (uuid, dep) in deps
+            if dep.name == package_name
+                return dep.version
+            end
+        end
+        return nothing
+    catch e
+        return nothing
+    end
+end
+
+"""
+    install_package(name::String, version::String; retry_count::Int=3)
+
+Install a specific version of a package with retry logic.
+"""
+function install_package(name::String, version::String; retry_count::Int=3)
+    for attempt in 1:retry_count
+        try
+            print_info("Installing $name@$version (attempt $attempt/$retry_count)...")
+
+            # Use Pkg.add with specific version
+            Pkg.add(name=name, version=version)
+
+            # Verify installation
+            installed_version = get_installed_version(name)
+            if installed_version !== nothing
+                installed_str = string(installed_version)
+                if installed_str == version
+                    print_success("Successfully installed $name@$version")
+                    return true
+                else
+                    print_warning("Installed $name@$installed_str instead of $version")
+                    # Try to pin the exact version
+                    try
+                        Pkg.pin(name=name, version=version)
+                        installed_version = get_installed_version(name)
+                        installed_str = string(installed_version)
+                        if installed_str == version
+                            print_success("Successfully pinned $name@$version")
+                            return true
+                        end
+                    catch e
+                        print_warning("Could not pin $name to version $version")
+                    end
+                end
+            else
+                print_error("Failed to verify installation of $name")
+            end
+        catch e
+            print_warning("Attempt $attempt failed: $(sprint(showerror, e))")
+            if attempt < retry_count
+                print_info("Retrying...")
+                sleep(1)  # Wait before retry
+            end
+        end
+    end
+
+    print_error("Failed to install $name@$version after $retry_count attempts")
+    return false
+end
+
+"""
+    verify_installations()
+
+Verify that all required packages are installed with correct versions.
+"""
+function verify_installations()
+    print_section("Verifying Installations")
+
+    all_correct = true
+    mismatched = []
+
+    for (name, required_version) in REQUIRED_PACKAGES
+        installed_version = get_installed_version(name)
+
+        if installed_version === nothing
+            print_error("$name is not installed")
+            push!(mismatched, name)
+            all_correct = false
+        else
+            installed_str = string(installed_version)
+            if installed_str == required_version
+                print_success("$name@$installed_str ✓")
+            else
+                print_warning("$name: installed $installed_str, required $required_version")
+                push!(mismatched, name)
+                all_correct = false
+            end
+        end
+    end
+
+    return all_correct, mismatched
+end
+
+"""
+    activate_current_environment()
+
+Activate the current project environment.
+"""
+function activate_current_environment()
+    print_section("Activating Project Environment")
+
+    project_dir = dirname(@__FILE__)
+    print_info("Project directory: $project_dir")
+
+    try
+        Pkg.activate(project_dir)
+        print_success("Project environment activated")
+        return true
+    catch e
+        print_error("Failed to activate project environment: $(sprint(showerror, e))")
+        return false
+    end
+end
+
+"""
+    install_all_packages()
+
+Install all required packages with specific versions.
+"""
+function install_all_packages()
+    print_section("Installing Required Packages")
+
+    total = length(REQUIRED_PACKAGES)
+    success_count = 0
+    failed_packages = String[]
+
+    for (i, (name, version)) in enumerate(sort(collect(REQUIRED_PACKAGES), by=x->x[1]))
+        println("\n[$i/$total] Processing $name...")
+        if install_package(name, version)
+            success_count += 1
+        else
+            push!(failed_packages, name)
+        end
+    end
+
+    println("\n" * "="^70)
+    println("Installation Summary:")
+    println("  Successful: $success_count/$total")
+    println("  Failed: $(length(failed_packages))/$total")
+
+    if !isempty(failed_packages)
+        println("\nFailed packages:")
+        for pkg in failed_packages
+            println("  - $pkg")
+        end
+    end
+    println("="^70)
+
+    return isempty(failed_packages)
+end
+
+"""
+    resolve_dependencies()
+
+Resolve all package dependencies in the environment.
+"""
+function resolve_dependencies()
+    print_section("Resolving Dependencies")
+
+    try
+        print_info("Running Pkg.resolve()...")
+        Pkg.resolve()
+        print_success("Dependencies resolved successfully")
+        return true
+    catch e
+        print_error("Failed to resolve dependencies: $(sprint(showerror, e))")
+        print_warning("You may need to manually resolve conflicts")
+        return false
+    end
+end
+
+"""
+    precompile_packages()
+
+Precompile all installed packages.
+"""
+function precompile_packages()
+    print_section("Precompiling Packages")
+
+    try
+        print_info("This may take several minutes...")
+        Pkg.precompile()
+        print_success("All packages precompiled successfully")
+        return true
+    catch e
+        print_error("Precompilation failed: $(sprint(showerror, e))")
+        print_warning("Some packages may not work correctly")
+        return false
+    end
+end
+
+"""
+    create_backup()
+
+Create a backup of the current Manifest.toml if it exists.
+"""
+function create_backup()
+    manifest_path = joinpath(dirname(@__FILE__), "Manifest.toml")
+
+    if isfile(manifest_path)
+        backup_path = joinpath(dirname(@__FILE__), "Manifest.toml.backup")
+        try
+            cp(manifest_path, backup_path, force=true)
+            print_info("Created backup: Manifest.toml.backup")
+            return true
+        catch e
+            print_warning("Failed to create backup: $(sprint(showerror, e))")
+            return false
+        end
+    end
+    return true
+end
+
+"""
+    print_final_summary(success::Bool)
+
+Print a final summary of the installation process.
+"""
+function print_final_summary(success::Bool)
+    println("\n" * "="^70)
+    if success
+        println("$(COLOR_GREEN)Installation completed successfully!$(COLOR_RESET)")
+        println("\nYou can now use Jexpresso with the correct package versions.")
+        println("To get started, run:")
+        println("  julia --project=. your_script.jl")
+    else
+        println("$(COLOR_RED)Installation completed with errors$(COLOR_RESET)")
+        println("\nSome packages could not be installed with the required versions.")
+        println("Please check the error messages above and try:")
+        println("  1. Updating Julia to version $MIN_JULIA_VERSION or higher")
+        println("  2. Running this script again")
+        println("  3. Manually installing failed packages using:")
+        println("     julia> using Pkg")
+        println("     julia> Pkg.add(name=\"PackageName\", version=\"x.y.z\")")
+    end
+    println("="^70 * "\n")
+end
+
+"""
+    main()
+
+Main installation routine.
+"""
+function main()
+    print_header()
+
+    # Step 1: Check Julia version
+    if !check_julia_version()
+        print_final_summary(false)
+        return 1
+    end
+
+    # Step 2: Activate project environment
+    if !activate_current_environment()
+        print_final_summary(false)
+        return 1
+    end
+
+    # Step 3: Create backup
+    create_backup()
+
+    # Step 4: Install required packages
+    install_success = install_all_packages()
+
+    # Step 5: Resolve dependencies
+    resolve_success = resolve_dependencies()
+
+    # Step 6: Verify installations
+    verify_success, mismatched = verify_installations()
+
+    # Step 7: Precompile (optional, continue even if it fails)
+    if install_success && resolve_success && verify_success
+        precompile_packages()
+    end
+
+    # Final summary
+    overall_success = install_success && resolve_success && verify_success
+    print_final_summary(overall_success)
+
+    return overall_success ? 0 : 1
+end
+
+# Run main function
+exit(main())


### PR DESCRIPTION
This commit adds a comprehensive installation system to ensure users can install Jexpresso with the correct package versions, especially important for the yt/wallmodel branch which will soon replace master.

Changes:
- install_dependencies.jl: Robust Julia script that installs all required packages with specific versions, includes retry logic, version verification, and comprehensive error handling
- install.sh: Convenient bash wrapper script for the installer
- INSTALLATION.md: Detailed installation guide with troubleshooting
- QUICKSTART.md: Quick reference guide for new users

The installer automatically:
- Checks Julia version compatibility (requires 1.11.2+)
- Creates backups of Manifest.toml
- Installs packages with exact versions:
  * MPI 0.20.22
  * MPIPreferences 0.1.11
  * PackageCompiler 2.2.1
  * Thermodynamics 0.12.7
  * PrettyTables 2.4.0
  * Crayons 4.1.1
  * UnicodePlots 3.7.2
  * Gridap v0.18.12
  * GridapDistributed v0.4.7
  * GridapGmsh v0.7.2
  * GridapP4est v0.3.11
- Verifies installations
- Handles errors with retry logic
- Precompiles packages
- Provides clear, colored terminal output

This addresses installation issues users may encounter when downloading the yt/wallmodel branch due to dependency version incompatibilities.