### PR TITLE
Update rhs.jl

### DIFF
--- a/src/kernel/operators/rhs.jl
+++ b/src/kernel/operators/rhs.jl
@@ -1426,7 +1426,7 @@ function _expansion_visc!(rhs_diffξ_el, uprimitiveieq, visc_coeffieq, ω,
         dξdx_kl = dqdξ*dξdx[iel,k]
         dqdx = visc_coeffieq[ieq]*dξdx_kl
         
-        ∇ξ∇u_kl = dξdx_kl*dqdx*ωJac
+        ∇ξ∇u_kl = dξdx[iel,k]*dqdx*ωJac
         
         @turbo for i = 1:ngl
             dhdξ_ik = dψ[i,k]


### PR DESCRIPTION
1D diffusion construction is incorrect results in something similar to (du/dx)^2 instead of (d^2u/dx^2). Fix with proposed change.