### PR TITLE
Fix cross-case method contamination when running multiple cases in the same REPL

### DIFF
--- a/problems/AdvDiff/2d/user_source.jl
+++ b/problems/AdvDiff/2d/user_source.jl
@@ -1,12 +1,23 @@
 function user_source!(S,
-                      q, 
+                      q,
                       qe,
-                      npoin::Int64,
-                      ::CL, ::AbstractPert;
+                      npoin,
+                      ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
     S[1] = 0.0
-   
+
+end
+
+function user_source!(S,
+                      q,
+                      qe,
+                      npoin,
+                      ::CL, ::TOTAL;
+                      neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
+
+    S[1] = 0.0
+
 end
 
 function user_source_gpu(q,qe,x,y,PhysConst, xmax, xmin, ymax, ymin,lpert)

--- a/problems/AdvDiff/2d_Laguerre/user_primitives.jl
+++ b/problems/AdvDiff/2d_Laguerre/user_primitives.jl
@@ -12,6 +12,6 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::PERT, uout, u, qe; kwargs...)
     uout[1] = u[1] #+qe[1]
 end

--- a/problems/AdvDiff/2d_Laguerre/user_source.jl
+++ b/problems/AdvDiff/2d_Laguerre/user_source.jl
@@ -1,12 +1,23 @@
 function user_source!(S,
-                      q, 
+                      q,
                       qe,
-                      npoin::Int64,
-                      ::CL, ::AbstractPert;
+                      npoin,
+                      ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
     S[1] = 0.0
-   
+
+end
+
+function user_source!(S,
+                      q,
+                      qe,
+                      npoin,
+                      ::CL, ::TOTAL;
+                      neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
+
+    S[1] = 0.0
+
 end
 
 function user_source_gpu(q,qe,x,y,PhysConst, xmax, xmin, ymax, ymin,lpert)

--- a/problems/AdvDiff/3d_double_periodic/user_source.jl
+++ b/problems/AdvDiff/3d_double_periodic/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1)
     
@@ -18,7 +18,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1)
 

--- a/problems/AdvDiff/3d_periodic/user_source.jl
+++ b/problems/AdvDiff/3d_periodic/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,karg...)
     
@@ -18,7 +18,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1, karg...)
 

--- a/problems/AdvDiff/Wave_Train/user_primitives.jl
+++ b/problems/AdvDiff/Wave_Train/user_primitives.jl
@@ -17,7 +17,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::PERT, uout, u, qe; kwargs...)
     uout[1] = u[1] #+ qe[1]
     uout[2] = u[2] #+ qe[2]    
 end

--- a/problems/AdvDiff/case1/user_primitives.jl
+++ b/problems/AdvDiff/case1/user_primitives.jl
@@ -11,6 +11,6 @@ function user_primitives_gpu(u, qe, lpert)
     return T(u[1]+qe[1])
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     uout[1] = u[1] #+qe[1]
 end

--- a/problems/AdvDiff/case1/user_source.jl
+++ b/problems/AdvDiff/case1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 

--- a/problems/AdvDiff/fd1d/user_source.jl
+++ b/problems/AdvDiff/fd1d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 

--- a/problems/AdvDiff/kopriva/user_source.jl
+++ b/problems/AdvDiff/kopriva/user_source.jl
@@ -1,12 +1,23 @@
 function user_source!(S,
-                      q, 
+                      q,
                       qe,
-                      npoin::Int64,
-                      ::CL, ::AbstractPert;
+                      npoin,
+                      ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
     S[1] = 0.0
-   
+
+end
+
+function user_source!(S,
+                      q,
+                      qe,
+                      npoin,
+                      ::CL, ::TOTAL;
+                      neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
+
+    S[1] = 0.0
+
 end
 
 function user_source_gpu(q,qe,x,y,PhysConst, xmax, xmin, ymax, ymin,lpert)

--- a/problems/Burgers/case1/user_primitives.jl
+++ b/problems/Burgers/case1/user_primitives.jl
@@ -11,6 +11,6 @@ function user_primitives_gpu(u, qe, lpert)
     return T(u[1] + qe[1])
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     uout[1] = u[1]
 end

--- a/problems/Burgers/case1/user_source.jl
+++ b/problems/Burgers/case1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 

--- a/problems/Burgers/case2d/user_primitives.jl
+++ b/problems/Burgers/case2d/user_primitives.jl
@@ -11,6 +11,6 @@ function user_primitives_gpu(u, qe, lpert)
     return T(u[1] + qe[1])
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     uout[1] = u[1]
 end

--- a/problems/Burgers/case2d/user_source.jl
+++ b/problems/Burgers/case2d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
@@ -12,7 +12,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 

--- a/problems/CompEuler/2d/user_source.jl
+++ b/problems/CompEuler/2d/user_source.jl
@@ -1,4 +1,4 @@
-function user_source!(S, q, npoin::Int64; neqs=1)
+function user_source!(S, q, npoin; neqs=1)
 
     PhysConst = PhysicalConst{Float64}()
         
@@ -14,7 +14,7 @@ function user_source!(S, q, npoin::Int64; neqs=1)
     
 end
 
-function user_source(q::Array, npoin::Int64; neqs=1)
+function user_source(q::Array, npoin; neqs=1)
 
     PhysConst = PhysicalConst{Float64}()
     S = zeros(Float64, neqs)

--- a/problems/CompEuler/3d/user_primitives.jl
+++ b/problems/CompEuler/3d/user_primitives.jl
@@ -24,7 +24,7 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     #
     # IMPORTANT NOTICE:

--- a/problems/CompEuler/3d/user_source.jl
+++ b/problems/CompEuler/3d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,
@@ -29,7 +29,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/3dAlya/user_primitives.jl
+++ b/problems/CompEuler/3dAlya/user_primitives.jl
@@ -24,7 +24,7 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     #
     # IMPORTANT NOTICE:

--- a/problems/CompEuler/3dAlya/user_source.jl
+++ b/problems/CompEuler/3dAlya/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,
@@ -29,7 +29,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/3d_amr/user_primitives.jl
+++ b/problems/CompEuler/3d_amr/user_primitives.jl
@@ -24,7 +24,7 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     #
     # IMPORTANT NOTICE:

--- a/problems/CompEuler/3d_amr/user_source.jl
+++ b/problems/CompEuler/3d_amr/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,
@@ -29,7 +29,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/3d_bomex/user_primitives.jl
+++ b/problems/CompEuler/3d_bomex/user_primitives.jl
@@ -27,7 +27,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/3d_bomex/user_source.jl
+++ b/problems/CompEuler/3d_bomex/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                     q, 
                     qe,
-                    npoin::Int64,
+                    npoin,
                     ::CL, ::TOTAL;
                     neqs=1,
                     x=0.0,
@@ -56,7 +56,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1)
 

--- a/problems/CompEuler/Cuyo/user_primitives.jl
+++ b/problems/CompEuler/Cuyo/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/Cuyo/user_source.jl
+++ b/problems/CompEuler/Cuyo/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LES/user_primitives.jl
+++ b/problems/CompEuler/LES/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LES/user_source.jl
+++ b/problems/CompEuler/LES/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP1/user_primitives.jl
+++ b/problems/CompEuler/LESICP1/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP1/user_source.jl
+++ b/problems/CompEuler/LESICP1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP2-coarse/user_primitives.jl
+++ b/problems/CompEuler/LESICP2-coarse/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP2-coarse/user_source.jl
+++ b/problems/CompEuler/LESICP2-coarse/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP2/user_primitives.jl
+++ b/problems/CompEuler/LESICP2/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP2/user_source.jl
+++ b/problems/CompEuler/LESICP2/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP3/user_primitives.jl
+++ b/problems/CompEuler/LESICP3/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP3/user_source.jl
+++ b/problems/CompEuler/LESICP3/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP4/user_primitives.jl
+++ b/problems/CompEuler/LESICP4/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP4/user_source.jl
+++ b/problems/CompEuler/LESICP4/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP5/user_primitives.jl
+++ b/problems/CompEuler/LESICP5/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP5/user_source.jl
+++ b/problems/CompEuler/LESICP5/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESICP6/user_primitives.jl
+++ b/problems/CompEuler/LESICP6/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESICP6/user_source.jl
+++ b/problems/CompEuler/LESICP6/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESWM/user_primitives.jl
+++ b/problems/CompEuler/LESWM/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/LESWM/user_source.jl
+++ b/problems/CompEuler/LESWM/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESlarge/user_primitives.jl
+++ b/problems/CompEuler/LESlarge/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESlarge/user_source.jl
+++ b/problems/CompEuler/LESlarge/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESsmago/user_primitives.jl
+++ b/problems/CompEuler/LESsmago/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESsmago/user_source.jl
+++ b/problems/CompEuler/LESsmago/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESsmagoMount/user_primitives.jl
+++ b/problems/CompEuler/LESsmagoMount/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESsmagoMount/user_source.jl
+++ b/problems/CompEuler/LESsmagoMount/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/LESsmagoMountSauerEtAl/user_primitives.jl
+++ b/problems/CompEuler/LESsmagoMountSauerEtAl/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/LESsmagoMountSauerEtAl/user_source.jl
+++ b/problems/CompEuler/LESsmagoMountSauerEtAl/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/Rayleigh_Benard/user_primitives.jl
+++ b/problems/CompEuler/Rayleigh_Benard/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u, qe, lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/Rayleigh_Benard/user_source.jl
+++ b/problems/CompEuler/Rayleigh_Benard/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/case1/user_source.jl
+++ b/problems/CompEuler/case1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=-5.0, xmax=5.0)
 

--- a/problems/CompEuler/city2d/user_source.jl
+++ b/problems/CompEuler/city2d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=1000.0, xmin=0.0, xmax=1000.0)
 
@@ -42,7 +42,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=1000.0, xmin=0.0, xmax=1000.0)
 
@@ -78,7 +78,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert;
                       neqs=1, x=0.0, y=0.0, ymin=0.0, ymax=1000.0, xmin=0.0, xmax=1000.0)

--- a/problems/CompEuler/dycomsDry/user_primitives.jl
+++ b/problems/CompEuler/dycomsDry/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
     

--- a/problems/CompEuler/dycomsDry/user_source.jl
+++ b/problems/CompEuler/dycomsDry/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/giga_les/user_primitives.jl
+++ b/problems/CompEuler/giga_les/user_primitives.jl
@@ -28,33 +28,31 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; mp = mp)
+function user_uout!(ip, ::TOTAL, uout, u, qe; mp = mp)
+    uout[1] = u[1]
+    uout[2] = u[2]/u[1]
+    uout[3] = u[3]/u[1]
+    uout[4] = u[4]/u[1]
+    uout[5] = u[5]/u[1]
+    uout[6] = u[6]/u[1]
+    uout[7] = u[7]/u[1]
+end
 
-    if ET == TOTAL()
-        uout[1] = u[1]
-        uout[2] = u[2]/u[1]
-        uout[3] = u[3]/u[1]
-        uout[4] = u[4]/u[1]
-        uout[5] = u[5]/u[1]
-        uout[6] = u[6]/u[1]
-        uout[7] = u[7]/u[1]
-    elseif ET == PERT()
-        uout[1] = u[1]+qe[1]
-        uout[2] = u[2]/(u[1]+qe[1])
-        uout[3] = u[3]/(u[1]+qe[1])
-        uout[4] = u[4]/(u[1]+qe[1])
-        uout[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
-        uout[6] = (u[6]+qe[6])/(u[1]+qe[1])-qe[6]/qe[1]
-        uout[7] = (u[7]+qe[7])/(u[1]+qe[1])-qe[7]/qe[1]
-        uout[8] = mp.Tabs[ip]
-        uout[9] = mp.qn[ip]
-        uout[10] = mp.qc[ip]
-        uout[11] = mp.qi[ip]
-        uout[12] = mp.qr[ip]
-        uout[13] = mp.qs[ip]
-        uout[14] = mp.qg[ip]
-        uout[15] = mp.qsatt[ip]
-    end
-        
+function user_uout!(ip, ::PERT, uout, u, qe; mp = mp)
+    uout[1] = u[1]+qe[1]
+    uout[2] = u[2]/(u[1]+qe[1])
+    uout[3] = u[3]/(u[1]+qe[1])
+    uout[4] = u[4]/(u[1]+qe[1])
+    uout[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
+    uout[6] = (u[6]+qe[6])/(u[1]+qe[1])-qe[6]/qe[1]
+    uout[7] = (u[7]+qe[7])/(u[1]+qe[1])-qe[7]/qe[1]
+    uout[8] = mp.Tabs[ip]
+    uout[9] = mp.qn[ip]
+    uout[10] = mp.qc[ip]
+    uout[11] = mp.qi[ip]
+    uout[12] = mp.qr[ip]
+    uout[13] = mp.qs[ip]
+    uout[14] = mp.qg[ip]
+    uout[15] = mp.qsatt[ip]
 end
 

--- a/problems/CompEuler/giga_les_MOST/user_primitives.jl
+++ b/problems/CompEuler/giga_les_MOST/user_primitives.jl
@@ -28,32 +28,14 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; mp = mp)
-
-    if ET == TOTAL()
-        uout[1] = u[1]
-        uout[2] = u[2]/u[1]
-        uout[3] = u[3]/u[1]
-        uout[4] = u[4]/u[1]
-        uout[5] = u[5]/u[1]
-        uout[6] = u[6]/u[1]
-        uout[7] = u[7]/u[1]
-
-        uout[16] = u[2]/u[1]-qe[2]/qe[1]
-        uout[17] = u[3]/u[1]-qe[3]/qe[1]
-        uout[18] = u[4]/u[1]-qe[4]/qe[1]
-        uout[19] = u[5]/u[1]-qe[5]/qe[1]
-        uout[20] = u[end]
-    elseif ET == PERT()
-        uout[1] = u[1]+qe[1]
-        uout[2] = u[2]/(u[1]+qe[1])
-        uout[3] = u[3]/(u[1]+qe[1])
-        uout[4] = u[4]/(u[1]+qe[1])
-        uout[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
-        uout[6] = (u[6]+qe[6])/(u[1]+qe[1])-qe[6]/qe[1]
-        uout[7] = (u[7]+qe[7])/(u[1]+qe[1])-qe[7]/qe[1]
-        
-    end
+function user_uout!(ip, ::TOTAL, uout, u, qe; mp = mp)
+    uout[1] = u[1]
+    uout[2] = u[2]/u[1]
+    uout[3] = u[3]/u[1]
+    uout[4] = u[4]/u[1]
+    uout[5] = u[5]/u[1]
+    uout[6] = u[6]/u[1]
+    uout[7] = u[7]/u[1]
     uout[8] = mp.Tabs[ip]
     uout[9] = mp.qn[ip]
     uout[10] = mp.qc[ip]
@@ -62,6 +44,28 @@ function user_uout!(ip, ET, uout, u, qe; mp = mp)
     uout[13] = mp.qs[ip]
     uout[14] = mp.qg[ip]
     uout[15] = mp.qsatt[ip]
-        
+    uout[16] = u[2]/u[1]-qe[2]/qe[1]
+    uout[17] = u[3]/u[1]-qe[3]/qe[1]
+    uout[18] = u[4]/u[1]-qe[4]/qe[1]
+    uout[19] = u[5]/u[1]-qe[5]/qe[1]
+    uout[20] = u[end]
+end
+
+function user_uout!(ip, ::PERT, uout, u, qe; mp = mp)
+    uout[1] = u[1]+qe[1]
+    uout[2] = u[2]/(u[1]+qe[1])
+    uout[3] = u[3]/(u[1]+qe[1])
+    uout[4] = u[4]/(u[1]+qe[1])
+    uout[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
+    uout[6] = (u[6]+qe[6])/(u[1]+qe[1])-qe[6]/qe[1]
+    uout[7] = (u[7]+qe[7])/(u[1]+qe[1])-qe[7]/qe[1]
+    uout[8] = mp.Tabs[ip]
+    uout[9] = mp.qn[ip]
+    uout[10] = mp.qc[ip]
+    uout[11] = mp.qi[ip]
+    uout[12] = mp.qr[ip]
+    uout[13] = mp.qs[ip]
+    uout[14] = mp.qg[ip]
+    uout[15] = mp.qsatt[ip]
 end
 

--- a/problems/CompEuler/giga_les_MOST/user_source.jl
+++ b/problems/CompEuler/giga_les_MOST/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,
@@ -98,7 +98,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/giga_les_theta/user_primitives.jl
+++ b/problems/CompEuler/giga_les_theta/user_primitives.jl
@@ -24,27 +24,23 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; mp = mp)
+function user_uout!(ip, ::TOTAL, uout, u, qe; mp = mp)
     PhysConst = PhysicalConst{Float64}()
+    uout[1] = u[1]
+    uout[2] = u[2]/u[1]
+    uout[3] = u[3]/u[1]
+    uout[4] = u[4]/u[1]
+    uout[5] = u[5]/u[1]
+    uout[6] = u[5]/u[1]-qe[5]/qe[1]
+    uout[7] = perfectGasLaw_ρθtoP(PhysConst, ρ=u[1], θ=u[5]/u[1])
+end
 
-    if ET == TOTAL()
-        uout[1] = u[1]
-        uout[2] = u[2]/u[1]
-        uout[3] = u[3]/u[1]
-        uout[4] = u[4]/u[1]
-        uout[5] = u[5]/u[1]
-        uout[6] = u[5]/u[1]-qe[5]/qe[1]
-        uout[7] = perfectGasLaw_ρθtoP(PhysConst, ρ=u[1], θ=u[5]/u[1])
-
-    elseif ET == PERT()
-        uout[1] = u[1]+qe[1]
-        uout[2] = u[2]/(u[1]+qe[1])
-        uout[3] = u[3]/(u[1]+qe[1])
-        uout[4] = u[4]/(u[1]+qe[1])
-        uout[5] = (u[5]+qe[5])/(u[1]+qe[1])
-        uout[6] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
-        
-    end
-        
+function user_uout!(ip, ::PERT, uout, u, qe; mp = mp)
+    uout[1] = u[1]+qe[1]
+    uout[2] = u[2]/(u[1]+qe[1])
+    uout[3] = u[3]/(u[1]+qe[1])
+    uout[4] = u[4]/(u[1]+qe[1])
+    uout[5] = (u[5]+qe[5])/(u[1]+qe[1])
+    uout[6] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 

--- a/problems/CompEuler/giga_les_theta/user_source.jl
+++ b/problems/CompEuler/giga_les_theta/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,
@@ -96,7 +96,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/kelvinHelmholtzChan2022/user_primitives.jl
+++ b/problems/CompEuler/kelvinHelmholtzChan2022/user_primitives.jl
@@ -57,7 +57,7 @@ function user_primitives_gpu(u, qe, lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     PhysConst = PhysicalConst{Float64}()
 

--- a/problems/CompEuler/kelvinHelmholtzChan2022/user_source.jl
+++ b/problems/CompEuler/kelvinHelmholtzChan2022/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -17,7 +17,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -38,7 +38,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/nozzleanderson/user_source.jl
+++ b/problems/CompEuler/nozzleanderson/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1, x=1, y=1, xmax=1, xmin=1, ymax=1)
 

--- a/problems/CompEuler/owenEtAl/user_primitives.jl
+++ b/problems/CompEuler/owenEtAl/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/owenEtAl/user_source.jl
+++ b/problems/CompEuler/owenEtAl/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/sod1d/user_source.jl
+++ b/problems/CompEuler/sod1d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=1.0)
 

--- a/problems/CompEuler/squall_line_2D/user_primitives.jl
+++ b/problems/CompEuler/squall_line_2D/user_primitives.jl
@@ -26,7 +26,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, ue; mp=mp)
+function user_uout!(ip, ::PERT, uout, u, ue; mp=mp)
 
     uout[1] = u[1]
     ρ = uout[1] + ue[1]

--- a/problems/CompEuler/squall_line_experiment/user_primitives.jl
+++ b/problems/CompEuler/squall_line_experiment/user_primitives.jl
@@ -28,7 +28,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, ue; kwargs...)
+function user_uout!(ip, ::PERT, uout, u, ue; kwargs...)
     uout[1] = ue[1]
     uout[2] = ue[2]/ue[1]
     uout[3] = ue[3]/ue[1]

--- a/problems/CompEuler/squall_line_experiment_LinEtAl/user_primitives.jl
+++ b/problems/CompEuler/squall_line_experiment_LinEtAl/user_primitives.jl
@@ -24,7 +24,7 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     #
     # IMPORTANT NOTICE:

--- a/problems/CompEuler/tcf/user_primitives.jl
+++ b/problems/CompEuler/tcf/user_primitives.jl
@@ -14,7 +14,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
     uprimitive[5] = (u[5]+qe[5])/(u[1]+qe[1])-qe[5]/qe[1]
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/tcf/user_source.jl
+++ b/problems/CompEuler/tcf/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0,

--- a/problems/CompEuler/theta/user_source.jl
+++ b/problems/CompEuler/theta/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/thetaAlya/user_source.jl
+++ b/problems/CompEuler/thetaAlya/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/thetaHole/user_primitives.jl
+++ b/problems/CompEuler/thetaHole/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     uout[1] = u[1]
     uout[2] = u[2]/u[1]
     uout[3] = u[3]/u[1]

--- a/problems/CompEuler/thetaHole/user_source.jl
+++ b/problems/CompEuler/thetaHole/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/thetaNC/user_source.jl
+++ b/problems/CompEuler/thetaNC/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -17,7 +17,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -38,7 +38,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/thetaNablaP/user_source.jl
+++ b/problems/CompEuler/thetaNablaP/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/thetaTracers/user_primitives.jl
+++ b/problems/CompEuler/thetaTracers/user_primitives.jl
@@ -26,7 +26,7 @@ function user_primitives_gpu(u,qe,lpert)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/thetaTracers/user_source.jl
+++ b/problems/CompEuler/thetaTracers/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 

--- a/problems/CompEuler/theta_dsgs/user_source.jl
+++ b/problems/CompEuler/theta_dsgs/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/theta_laguerre/user_primitives.jl
+++ b/problems/CompEuler/theta_laguerre/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::PERT, uout, u, qe; kwargs...)
     uout[1] = u[1]
     uout[2] = u[2]/(u[1] + qe[1]) + 10
     uout[3] = u[3]/(u[1] + qe[1])

--- a/problems/CompEuler/theta_laguerre/user_source.jl
+++ b/problems/CompEuler/theta_laguerre/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -65,7 +65,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/theta_periodic/user_primitives.jl
+++ b/problems/CompEuler/theta_periodic/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u, qe, lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/theta_periodic/user_source.jl
+++ b/problems/CompEuler/theta_periodic/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/theta_pert/user_source.jl
+++ b/problems/CompEuler/theta_pert/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/problems/CompEuler/trixiWave/user_primitives.jl
+++ b/problems/CompEuler/trixiWave/user_primitives.jl
@@ -9,7 +9,7 @@ function user_primitives!(u,qe,uprimitive,::PERT)
 end
 
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     
     PhysConst = PhysicalConst{Float64}()
 

--- a/problems/CompEuler/trixiWave/user_source.jl
+++ b/problems/CompEuler/trixiWave/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
     

--- a/problems/CompEuler/vortex/user_primitives.jl
+++ b/problems/CompEuler/vortex/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u, qe, lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/CompEuler/vortex/user_source.jl
+++ b/problems/CompEuler/vortex/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 

--- a/problems/CompEuler/wave1d-fd/user_source.jl
+++ b/problems/CompEuler/wave1d-fd/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
     

--- a/problems/CompEuler/wave1d/user_source.jl
+++ b/problems/CompEuler/wave1d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
     

--- a/problems/CompEuler/wave1d_lag/user_primitives.jl
+++ b/problems/CompEuler/wave1d_lag/user_primitives.jl
@@ -17,7 +17,7 @@ function user_primitives_gpu(u,qe,lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
     uout[1] = u[1] #+ qe[1]
     uout[2] = u[2] #+ qe[2]    
 end

--- a/problems/CompEuler/wave1d_lag/user_source.jl
+++ b/problems/CompEuler/wave1d_lag/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1, x=0.0, y=0.0, xmin=0.0, xmax=1.0)
     

--- a/problems/Elliptic/2dlaplace/user_source.jl
+++ b/problems/Elliptic/2dlaplace/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=1.0, y=1.0,

--- a/problems/Elliptic/case1/user_source.jl
+++ b/problems/Elliptic/case1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=1.0, y=1.0,

--- a/problems/Elliptic/elementLearning/user_bc.jl
+++ b/problems/Elliptic/elementLearning/user_bc.jl
@@ -24,7 +24,7 @@
     where  `qibdy[i=1:nvar]` is the value unknown `i`
     
 """
-function user_bc_dirichlet!(q::SubArray{Float64}, coords, t::AbstractFloat, tag::String, qbdy::AbstractArray, nx, ny,qe::SubArray{Float64},::TOTAL)
+function user_bc_dirichlet!(q, coords, t::AbstractFloat, tag::String, qbdy::AbstractArray, nx, ny,qe,::TOTAL)
 
     L = 5.0
     #qbdy[1] = 1.0

--- a/problems/Elliptic/elementLearning/user_source.jl
+++ b/problems/Elliptic/elementLearning/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=1.0, y=1.0,

--- a/problems/Elliptic/elementLearning_hole/user_bc.jl
+++ b/problems/Elliptic/elementLearning_hole/user_bc.jl
@@ -24,7 +24,7 @@
     where  `qibdy[i=1:nvar]` is the value unknown `i`
     
 """
-function user_bc_dirichlet!(q::SubArray{Float64}, coords, t::AbstractFloat, tag::String, qbdy::AbstractArray, nx, ny,qe::SubArray{Float64},::TOTAL)
+function user_bc_dirichlet!(q, coords, t::AbstractFloat, tag::String, qbdy::AbstractArray, nx, ny,qe,::TOTAL)
 
     L = 2.0
     #qbdy[1] = 1.0

--- a/problems/Elliptic/elementLearning_hole/user_source.jl
+++ b/problems/Elliptic/elementLearning_hole/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=1.0, y=1.0,

--- a/problems/Helmholtz/case1/user_source.jl
+++ b/problems/Helmholtz/case1/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0, y=0.0,

--- a/problems/Helmholtz/case1_laguerre/user_source.jl
+++ b/problems/Helmholtz/case1_laguerre/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,
                       x=0.0, y=0.0,

--- a/problems/ShallowWater/SoliWaveIsland/user_source.jl
+++ b/problems/ShallowWater/SoliWaveIsland/user_source.jl
@@ -44,7 +44,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
 
@@ -66,7 +66,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
     user_source!(S, q, qe, npoin, CL(), TOTAL();

--- a/problems/ShallowWater/TC2/user_source.jl
+++ b/problems/ShallowWater/TC2/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
     #
@@ -23,7 +23,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
     f0 = 1.0e-4

--- a/problems/ShallowWater/TC3/user_source.jl
+++ b/problems/ShallowWater/TC3/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q,
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
     #
@@ -63,7 +63,7 @@ end
 function user_source!(S,
                       q,
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=3, x=0.0, y=0.0, ymin=0.0, ymax=0.0, xmin=0.0, xmax=0.0)
     f0    = 1.0e-4

--- a/problems/acoustics/acoustics2d/user_primitives.jl
+++ b/problems/acoustics/acoustics2d/user_primitives.jl
@@ -21,7 +21,7 @@ function user_primitives_gpu(u, qe, lpert)
     end
 end
 
-function user_uout!(ip, ET, uout, u, qe; kwargs...)
+function user_uout!(ip, ::TOTAL, uout, u, qe; kwargs...)
 
     uout[1] = u[1]
     uout[2] = u[2]/u[1]

--- a/problems/acoustics/acoustics2d/user_source.jl
+++ b/problems/acoustics/acoustics2d/user_source.jl
@@ -1,7 +1,7 @@
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::TInt,
+                      npoin,
                       ::CL, ::TOTAL;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -22,7 +22,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::CL, ::PERT;
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)
 
@@ -43,7 +43,7 @@ end
 function user_source!(S,
                       q, 
                       qe,
-                      npoin::Int64,
+                      npoin,
                       ::NCL,
                       ::AbstractPert; #for NCL() there is no differece between PERT() and TOTAL() in the source
                       neqs=1,x=0.0, y=0.0, ymin=0.0, ymax=30000.0, xmin = -120000, xmax =120000)

--- a/src/run.jl
+++ b/src/run.jl
@@ -129,6 +129,21 @@ _case_load_files = [driver_file, user_input_file, user_flux_file,
 _need_case_reload = (_LOADED_CASE_DIR[] != case_name_dir) ||
     any(f -> get(_CASE_FILE_MTIMES, f, -1.0) != mtime(f), _case_load_files)
 if _need_case_reload
+    # Clear all methods of the user_* dispatch functions before reloading.
+    # These functions are never defined in src/ — every method comes from a
+    # case file — so deleting them all is safe and avoids cross-case
+    # contamination (e.g. theta's user_source!/user_uout! persisting into
+    # an RT case or Wave_Train).  Path-based filtering was unreliable because
+    # m.file may use tilde-abbreviated or otherwise non-canonical paths.
+    for _fname in (:user_flux!, :user_source!, :user_bc_dirichlet!,
+                   :user_primitives!, :user_uout!)
+        if isdefined(@__MODULE__, _fname)
+            _func = getfield(@__MODULE__, _fname)
+            for _m in collect(methods(_func))
+                Base.delete_method(_m)
+            end
+        end
+    end
     for _f in _case_load_files
         include(_f)
         _CASE_FILE_MTIMES[_f] = mtime(_f)


### PR DESCRIPTION
## Summary

- **Root cause**: When running case A then case B in the same Julia session, methods defined in A's `user_source.jl`/`user_primitives.jl`/`user_bc.jl` persist in the global method table and silently override B's methods.
- **`src/run.jl`**: Before reloading case files, explicitly delete all methods of `user_flux!`, `user_source!`, `user_bc_dirichlet!`, `user_primitives!`, `user_uout!`. These functions have no definitions in `src/` — every method comes from a case file — so a full delete-then-reload is safe.
- **108 case files** across all problem directories (`AdvDiff`, `Burgers`, `CompEuler`, `Elliptic`, `Helmholtz`, `ShallowWater`, `acoustics`): replace runtime `ET == TOTAL()` / `ET == PERT()` checks with proper `::TOTAL` / `::PERT` type dispatch, and remove `::TInt` / `::Int64` type annotations on `npoin`. This makes methods unambiguous when reloaded and ensures correct dispatch without relying on stale method ordering.

## Test plan

- [ ] Run case A (e.g. `theta`) in a REPL session, then immediately run case B (e.g. `3d`) without restarting Julia — verify B uses its own `user_source!` and not A's
- [ ] Verify all existing single-case runs still produce correct output
- [ ] Confirm no method ambiguity warnings on reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)