### PR TITLE
Exact geometry (for circles only for now)

### DIFF
--- a/problems/CompEuler/shock_circle/user_inputs.jl
+++ b/problems/CompEuler/shock_circle/user_inputs.jl
@@ -78,6 +78,24 @@ function user_inputs()
         :lread_gmsh           => true,
         :gmsh_filename        => "./meshes/gmsh_grids/ffs_step_transfinite.msh",
         :gmsh_filename        => "./problems/CompEuler/shock_circle/plate_hole_circle_unit.msh",
+        # EXACT GEOMETRY. plate_hole_circle_unit.geo defines the hole as a gmsh
+        # `Circle`, but the .msh is straight-sided: the 16 boundary vertices sit
+        # on the circle of radius 0.2 at (1, 0) and every high-order node in
+        # between sits on the CHORD, up to 3.8e-3 inside the wall. That polygon
+        # is what the solver would otherwise see however large :nop is, and its
+        # sixteen corners are sixteen places for a slip wall to shed spurious
+        # vorticity into a Mach-3 flow.
+        #
+        # This snaps the boundary nodes onto the circle and blends the
+        # correction into the touching elements (Gordon-Hall, see
+        # src/kernel/mesh/exact_geometry.jl). The wall becomes the degree-:nop
+        # isoparametric interpolant of the true circle — 4.4e-8 from it at
+        # :nop => 4 instead of 3.8e-3, a factor of 10^5.
+        #
+        # `:circle` means "fit the centre and radius from the boundary vertices
+        # the mesh file already carries", which recovers (1.0, 0.0) and 0.2
+        # here. Write (:circle, 1.0, 0.0, 0.2) instead to state them outright.
+        :exact_geometry       => Dict("circle_boundary" => :circle),
         #---------------------------------------------------------------------------
         # Plotting
         #---------------------------------------------------------------------------

--- a/problems/CompEuler/shock_circle/user_inputs.jl
+++ b/problems/CompEuler/shock_circle/user_inputs.jl
@@ -1,61 +1,13 @@
 function user_inputs()
 
     inputs = Dict(
-        #---------------------------------------------------------------------------
-        #
-        # 2D CompEuler: Mach-3 supersonic flow over a forward-facing step.
-        #
-        # Wind tunnel 3 m x 1 m with a 0.2 m step 0.6 m from the inflow; the
-        # tunnel is filled with, and fed from the left by, a uniform Mach-3
-        # stream of air at p = 101325 Pa, T = 293 K (|u| ≈ 1029 m/s), per the
-        # Loci/STREAM "2D Supersonic Forward Step" tutorial. This is the
-        # dimensional form of Emery (1968) / Woodward & Colella (1984), also
-        # Section 5.1 of Nazarov & Hoffman (IJNMF 71:339-357, 2013).
-        #
-        # A bow shock stands off the step, reflects from the roof, and the
-        # reflections merge into a Mach stem. Everything interesting in this
-        # case is a discontinuity, which drives the two decisions below.
-        #
-        # (1) :energy_equation => "energy".  Slot 4 is ρE, not ρθ. ρθ is an
-        #     entropy variable: it is conserved across a contact but NOT
-        #     across a shock, so the Euler-θ system carries the wrong shock
-        #     speed no matter how it is stabilized.
-        #
-        # (2) :visc_model => DSGS().  Residual-based artificial viscosity as
-        #     shock capturing, Nazarov & Hoffman eq. (3.4)-(3.7): the
-        #     viscosity is proportional to the local residual of the
-        #     conservation laws, so it appears at the shocks and stays near
-        #     zero in the smooth 90% of the field. A constant AV() coefficient
-        #     large enough to hold the Mach-3 shocks would smear the whole
-        #     domain. The total-energy branch of compute_dsgs_viscosity! (2D)
-        #     is selected by :energy_equation above.
-        #---------------------------------------------------------------------------
         :ode_solver           => CarpenterKennedy2N54(),
         :tinit                => 0.0,
-        :tend                 => 8.0e-3,          # ≈ 2.7 tunnel flow-throughs
+        :tend                 => 2.0e-2,          # ≈ 2.7 tunnel flow-throughs
         :lrestart             => false,
         :restart_time         => 0.0,
-        # CFL. The grid is h = 0.025 m with :nop => 4, so the tightest LGL
-        # node spacing is ≈ 0.0043 m; against the free-stream wave speed
-        # |u| + c ≈ 1372 m/s that puts the ADVECTIVE limit near 1.4e-6 s.
-        # With :init_refine_lvl => 2 below, every one of those numbers
-        # shrinks by 4 (element size) and the viscous one by 16 (Δx²).
-        #
-        # The binding constraint is NOT advective, it is VISCOUS. DynSGS
-        # saturates its own μ_max bound at the step corner (measured: μ =
-        # 14.4 Pa·s against a local cap of 14.95), and μΔt/(ρΔx²) at
-        # Δt = 5e-7 is already ≈ 0.22 with :μ => 1.0. Scaling :μ up without
-        # scaling Δt down therefore blows the viscous limit — see the note
-        # on :μ below. The pair (Δt, :μ) has to move together.
         :Δt                   => 0.5e-7,
-        :diagnostics_at_times => (0:5.0e-5:8.0e-3),
-        # Wall-clock note, not a setting: at Δt = 1.25e-7 the diagnostics
-        # above are 3200 steps apart, so the CFL/VTK lines are ~35-40 min
-        # apart and the whole run is 64000 steps, order 12 h on one core.
-        # A long silence after "Integrator warm-up with real callbacks" is
-        # the run working, not a hang. If you ever want to watch it step,
-        # `JEXPRESSO_STEP_HEARTBEAT=1` turns on a per-step trace without
-        # editing this deck.
+        :diagnostics_at_times => (0:5.0e-5:2.0e-2),
         :lsource              => false,
         :SOL_VARS_TYPE        => TOTAL(),
         #---------------------------------------------------------------------------
@@ -122,7 +74,7 @@ function user_inputs()
         # AMR off: the mesh already resolves the shocks at h/nop = 1/80, and
         # DynSGS is what handles what is left under-resolved.
         #---------------------------------------------------------------------------
-        :linitial_refine      => false,
+        :linitial_refine      => true,
         :init_refine_lvl      => 1,
         :ladapt               => false,
     ) #Dict

--- a/src/io/mod_inputs.jl
+++ b/src/io/mod_inputs.jl
@@ -847,6 +847,45 @@ function mod_inputs_user_inputs!(inputs, rank = 0)
                          " is not recognised. Use :none or one of ", CUBED_SPHERE_MAPS, "."))
     end
     #
+    #   :exact_geometry    2D ONLY. Curve the high-order nodes of the named
+    #                      boundaries onto the exact shape the .geo defined,
+    #                      instead of leaving them on the straight-sided chords
+    #                      gmsh wrote. See src/kernel/mesh/exact_geometry.jl for
+    #                      the construction (isoparametric boundary + Gordon-Hall
+    #                      blend) and why it is the one Kopriva (2006) sanctions.
+    #
+    #                      Absent (the default) nothing is curved and every case
+    #                      behaves exactly as before. Otherwise it is a Dict
+    #                      from gmsh `Physical Curve` name to shape:
+    #
+    #                        Dict("circle_boundary" => :circle)
+    #                                centre and radius FITTED from the boundary
+    #                                vertices the mesh file already carries, and
+    #                                refused if they do not lie on a circle.
+    #
+    #                        Dict("circle_boundary" => (:circle, 1.0, 0.0, 0.2))
+    #                                centre and radius stated outright.
+    #
+    #                      The grid must still resolve the curvature: an element
+    #                      thinner than the sagitta of its own boundary arc folds,
+    #                      and exact_geometry.jl stops the run rather than hand a
+    #                      negative Jacobian to the metrics.
+    #
+    if haskey(inputs, :exact_geometry)
+        _eg = inputs[:exact_geometry]
+        _eg isa AbstractDict ||
+            error(string(" # ERROR mod_inputs.jl: :exact_geometry must be a Dict of ",
+                         "\"boundary tag\" => shape, got ", typeof(_eg), "."))
+        for (_tag, _sh) in _eg
+            _ok = _sh === :circle ||
+                  (_sh isa Tuple && length(_sh) == 4 && _sh[1] === :circle &&
+                   all(v -> v isa Real, _sh[2:4]) && _sh[4] > 0)
+            _ok || error(string(" # ERROR mod_inputs.jl: :exact_geometry[\"", _tag,
+                                "\"] => ", _sh, " is not a shape I know. Use :circle ",
+                                "(fitted) or (:circle, xc, yc, r) with r > 0."))
+        end
+    end
+    #
     #   :sphere_metrics    the 2D-manifold metric terms of build_sphere_metrics.
     #                      Kopriva's curl-invariant form (J. Sci. Comput. 26(3),
     #                      301, 2006, Eq. 15; Sec. 3.2.3 of Kelly, Alves,

--- a/src/kernel/coupling/couplingStructs.jl
+++ b/src/kernel/coupling/couplingStructs.jl
@@ -192,6 +192,9 @@ const _CACHE_FINGERPRINT_KEYS = (
     :lpreadapt, :preadapt_max_level, :amr_max_level, :lrestart_amr,
     :lxy_partition, :lwarp,
     :lproject_to_sphere, :sphere_radius, :cubed_sphere_map,
+    # Curving the boundary onto an exact shape MOVES nodes, so a cached mesh
+    # built with a different (or absent) :exact_geometry must not be reused.
+    :exact_geometry,
     :xscale, :yscale, :zscale, :xdisp, :ydisp, :zdisp,
     # Natively-built (non-gmsh) grids: the deck's element counts and domain
     # bounds ARE the mesh, and the cache file name only carries "native".

--- a/src/kernel/mesh/exact_geometry.jl
+++ b/src/kernel/mesh/exact_geometry.jl
@@ -1,0 +1,547 @@
+#---------------------------------------------------------------------------------
+# exact_geometry.jl
+#
+# Curve the high-order nodes of a 2D grid onto the EXACT geometry that the mesh
+# generator only approximated by straight sides.
+#
+# WHY
+# ---
+# gmsh writes a linear (straight-sided) grid: a `Circle` arc in the .geo comes
+# back as a polyline whose vertices happen to sit on the circle. Populating that
+# element with LGL nodes puts every high-order node on the CHORD, so no matter
+# how large `:nop` is, the boundary the solver sees is a polygon. The wall
+# normal is then wrong by O(h) at every node and a slip wall spuriously
+# generates vorticity at each polygon corner. This is the 2D analogue of what
+# `project_nodes_to_shell!` already does for a spherical shell, where the
+# high-order nodes are pushed back out onto the sphere.
+#
+# HOW  (Kopriva, J. Sci. Comput. 26(3):301-327, 2006)
+# ---------------------------------------------------------------------------
+# Section 3 of that paper states the standard element mapping: a LINEAR
+# BLENDING TRANSFINITE map (Gordon & Hall, 1973) between the four edge curves,
+# which is a polynomial in each direction when the curved sides are. That is
+# what is built here, in two steps:
+#
+#   1. Put the N+1 nodes of a boundary EDGE onto the exact curve. The degree-N
+#      Lagrange interpolant through them is the boundary representation Γ(ξ) —
+#      isoparametric, the same order as the solution. Kopriva's Remark 2 is
+#      explicit that this is enough and that representing the boundary to
+#      HIGHER order than N does not help.
+#
+#   2. Fill the element interior by blending the four edge curves. Linear
+#      blending of curves in P^N stays in P^N.
+#
+# Theorem 3 is what says this is safe: in 2D the cross-product metric terms
+#
+#       J a¹ = Y_η x̂ - X_η ŷ,      J a² = -Y_ξ x̂ + X_ξ ŷ                  (38)
+#
+# satisfy the discrete metric identities — and the scheme is therefore
+# constant-state preserving — iff the mapping they are computed from is in P^N.
+# `build_metric_terms!(…, NSD_2D)` differentiates the degree-N interpolant
+# through `mesh.x/y`, so its mapping is in P^N however the nodes are placed,
+# and curving the grid this way keeps free-stream preservation exactly. (What
+# Remark 4 warns against is the other route: substituting metric terms obtained
+# by analytically differentiating the true circular map. Jexpresso never does
+# that, and this file must not start.)
+#
+# Written in terms of the DISPLACEMENT δ = (curved node) - (straight node),
+# step 2 is
+#
+#   δ(ξ,η) = (1-η)/2 δ₁(ξ) + (1+η)/2 δ₂(ξ) + (1-ξ)/2 δ₃(η) + (1+ξ)/2 δ₄(η)
+#            - [bilinear corner terms]
+#
+# and the corner terms VANISH here, because the element corners are the linear
+# gmsh vertices and those are left exactly where gmsh put them (δ = 0 there).
+# Two consequences, both of which are why this routine needs no communication
+# and no neighbour bookkeeping:
+#
+#   * the blend of a curved edge is identically zero on the two edges adjacent
+#     to it, so a neighbouring element that does NOT touch the curved boundary
+#     sees its shared edge unmoved — the grid stays exactly conforming;
+#   * an element with two curved edges is handled by the plain sum above, with
+#     no double counting.
+#
+# Only the interior nodes of a boundary element, and the interior nodes of the
+# curved boundary edges themselves, ever move. Everything else is untouched.
+#
+# INPUT
+# -----
+#   :exact_geometry => Dict(<boundary tag> => <shape spec>)
+#
+# where <boundary tag> is the gmsh `Physical Curve` name and <shape spec> is
+# either
+#
+#   :circle                       centre and radius are FITTED (least squares)
+#                                 from the linear vertices the mesh file
+#                                 already carries on that boundary, and the fit
+#                                 is rejected if they do not actually lie on a
+#                                 circle — the same "trust the grid, but check
+#                                 it" policy as project_nodes_to_shell!;
+#
+#   (:circle, xc, yc, r)          centre and radius given explicitly.
+#
+# Example (problems/CompEuler/shock_circle/user_inputs.jl):
+#
+#   :exact_geometry => Dict("circle_boundary" => :circle),
+#
+# No key, or an empty Dict, means "do nothing" — every existing case is
+# unaffected.
+#
+# LIMITS
+# ------
+#   * 2D only. The 3D construction blends six FACE surfaces rather than four
+#     edge curves, and Theorem 5 of the same paper shows the cross-product
+#     metrics do NOT satisfy the metric identities there whatever the mapping
+#     is — 3D needs the conservative curl form as well, so it is its own change.
+#     NSD_1D and NSD_3D are explicit no-ops rather than silent ones.
+#
+#   * ONE ELEMENT LAYER. Only the elements that own a curved edge are curved,
+#     which is the standard construction (it is the mesh of Kopriva's Fig. 2)
+#     and is what keeps the correction local and the grid conforming. The grid
+#     must therefore already resolve the curvature: an element thinner, normal
+#     to the wall, than the sagitta of its own boundary arc folds, and
+#     _check_curved_elements stops the run rather than hand a negative Jacobian
+#     to build_metric_terms!.
+#
+#   * AMR. This runs inside mod_mesh_read_gmsh!, so an adapted grid is curved
+#     again from its own boundary vertices each time it is rebuilt. Those
+#     vertices come from refining the STRAIGHT-SIDED parent, so refinement
+#     brings the vertices onto the wall at the usual O(h²) and the curving then
+#     corrects the nodes between them — correct, but the h in "O(h^{N+1}) from
+#     the true circle" is the parent element's, not the child's, until the
+#     vertices themselves are put on the geometry. Untested with :ladapt.
+#---------------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------------
+# Shapes.
+#
+# A shape only has to answer one question: given a point, where is the nearest
+# point of the exact geometry? Adding :sphere / :cylinder for the 3D case is a
+# matter of adding a struct and a `snap_to_shape` method.
+#---------------------------------------------------------------------------------
+struct ExactCircle{T<:AbstractFloat}
+    xc::T
+    yc::T
+    r::T
+end
+
+Base.show(io::IO, c::ExactCircle) =
+    print(io, "circle(centre = (", c.xc, ", ", c.yc, "), r = ", c.r, ")")
+
+# Radial projection onto the circle. This is the 2D twin of the radial snap in
+# project_nodes_to_shell!, and it is shape-generic: any geometry that can name
+# its nearest point plugs in here unchanged. Theorem 3 does not care WHICH
+# parametrization of the arc the N+1 nodes end up at — only that they lie on
+# the curve, so that the interpolant through them is the P^N boundary.
+function snap_to_shape(c::ExactCircle, x, y)
+    dx = x - c.xc
+    dy = y - c.yc
+    d  = sqrt(dx*dx + dy*dy)
+    d > 0 || return (x, y)              # node sits on the centre: nothing to do
+    s = c.r/d
+    return (c.xc + s*dx, c.yc + s*dy)
+end
+
+
+# Characteristic length of a shape, for turning an absolute distance into a
+# relative one.
+_shape_scale(c::ExactCircle) = c.r
+
+
+#---------------------------------------------------------------------------------
+# Least-squares circle through a point cloud (Kåsa / algebraic fit).
+#
+# Minimises Σ (x² + y² + Dx + Ey + F)², i.e. the 3x3 normal system
+#
+#   [ Σx²  Σxy  Σx ] [D]     [ Σ x(x²+y²) ]
+#   [ Σxy  Σy²  Σy ] [E] = - [ Σ y(x²+y²) ]
+#   [ Σx   Σy   n  ] [F]     [ Σ  (x²+y²) ]
+#
+# with xc = -D/2, yc = -E/2, r = sqrt(xc² + yc² - F). The sums are formed
+# locally and Allreduced, so a partitioned grid fits the same circle on every
+# rank and the snapped coordinates agree bit-for-bit across a partition
+# boundary.
+#
+# Returns (circle, max relative radial residual) or `nothing` when the cloud is
+# degenerate (fewer than 3 points, or collinear — a straight boundary, for
+# which the normal system is singular).
+#---------------------------------------------------------------------------------
+function _fit_circle_mpi(xs::AbstractVector, ys::AbstractVector, comm)
+
+    s = zeros(Float64, 7)               # n, Σx, Σy, Σx², Σxy, Σy², Σ(x²+y²)
+    t = zeros(Float64, 3)               # Σx·q, Σy·q, Σq   with q = x²+y²
+    for k in eachindex(xs)
+        x = Float64(xs[k]); y = Float64(ys[k]); q = x*x + y*y
+        s[1] += 1.0; s[2] += x;   s[3] += y
+        s[4] += x*x; s[5] += x*y; s[6] += y*y; s[7] += q
+        t[1] += x*q; t[2] += y*q; t[3] += q
+    end
+    s = MPI.Allreduce(s, MPI.SUM, comm)
+    t = MPI.Allreduce(t, MPI.SUM, comm)
+
+    n = s[1]
+    n >= 3.0 || return nothing
+
+    A = [s[4] s[5] s[2];
+         s[5] s[6] s[3];
+         s[2] s[3] n]
+    b = -[t[1], t[2], t[3]]
+
+    # Collinear (or nearly so) => singular A => not a circle. Scale the
+    # determinant test by the cloud's own size so it is dimensionless.
+    scale = max(s[4] + s[6] - (s[2]^2 + s[3]^2)/n, eps(Float64))   # n·variance
+    abs(det(A)) > 1.0e-12 * n * scale^2 || return nothing
+
+    D, E, F = A \ b
+    xc = -0.5*D
+    yc = -0.5*E
+    disc = xc*xc + yc*yc - F
+    disc > 0.0 || return nothing
+    r = sqrt(disc)
+    r > 0.0 || return nothing
+
+    # Residual: how far the fitted circle actually is from the vertices it was
+    # fitted to. A polygonal boundary that is not a circle shows up here.
+    resid = 0.0
+    for k in eachindex(xs)
+        resid = max(resid, abs(sqrt((Float64(xs[k]) - xc)^2 + (Float64(ys[k]) - yc)^2) - r))
+    end
+    resid = MPI.Allreduce(resid, MPI.MAX, comm)
+
+    return (ExactCircle{TFloat}(TFloat(xc), TFloat(yc), TFloat(r)), resid/r)
+end
+
+
+#---------------------------------------------------------------------------------
+# D[k,i] = ℓ_i'(ξ_k): the nodal derivative matrix of the degree-N Lagrange basis
+# on the interpolation nodes, in barycentric form (Berrut & Trefethen 2004,
+# §9.3). Used here to check element validity, and by build_metric_terms! to get
+# the tangent along a curved boundary edge.
+#---------------------------------------------------------------------------------
+function lagrange_nodal_derivative_matrix(ξ::AbstractVector{T}) where {T<:AbstractFloat}
+    n = length(ξ)
+    w = ones(T, n)
+    @inbounds for j = 1:n, k = 1:n
+        k == j && continue
+        w[j] /= (ξ[j] - ξ[k])
+    end
+    D = zeros(T, n, n)
+    @inbounds for k = 1:n
+        acc = zero(T)
+        for i = 1:n
+            i == k && continue
+            D[k,i] = (w[i]/w[k])/(ξ[k] - ξ[i])
+            acc += D[k,i]
+        end
+        D[k,k] = -acc                    # rows sum to zero: d/dξ of a constant
+    end
+    return D
+end
+
+
+#---------------------------------------------------------------------------------
+# Resolve one <boundary tag> => <shape spec> entry into a concrete shape.
+#---------------------------------------------------------------------------------
+function _resolve_shape(tag::AbstractString, spec, xs, ys, comm, rank, suppress)
+
+    # (:circle, xc, yc, r) — the case deck states the geometry outright.
+    if spec isa Tuple && length(spec) == 4 && spec[1] === :circle
+        return ExactCircle{TFloat}(TFloat(spec[2]), TFloat(spec[3]), TFloat(spec[4]))
+    end
+
+    # :circle — fit it from what the grid file itself says.
+    if spec === :circle
+        fit = _fit_circle_mpi(xs, ys, comm)
+        if fit === nothing
+            println_rank(string(" #   :exact_geometry \"", tag,
+                                "\" => :circle ignored: its vertices are collinear or too few ",
+                                "to define a circle.");
+                         msg_rank = rank, suppress = suppress)
+            return nothing
+        end
+        circle, rresid = fit
+        if rresid > 1.0e-6
+            println_rank(string(" #   :exact_geometry \"", tag,
+                                "\" => :circle ignored: the boundary vertices are not on a circle ",
+                                "(best fit ", circle, " leaves a relative residual of ", rresid, ").");
+                         msg_rank = rank, suppress = suppress)
+            return nothing
+        end
+        return circle
+    end
+
+    error(" # ERROR exact_geometry.jl: :exact_geometry[\"" * String(tag) * "\"] => " *
+          string(spec) * " is not a shape I know.\n" *
+          " #   Use :circle (centre and radius fitted from the grid) or\n" *
+          " #   (:circle, xc, yc, r) to state them explicitly.")
+end
+
+
+#---------------------------------------------------------------------------------
+# snap_nodes_to_exact_geometry!(mesh, lgl, inputs, SD)
+#
+# The entry point, called from mod_mesh_read_gmsh! once the high-order nodes,
+# `connijk`, and the boundary-edge tables all exist. Rewrites `mesh.x/y` in
+# place; `mesh.coords` is filled from x/y at the end of mod_mesh_mesh_driver,
+# so the curved coordinates propagate everywhere (metrics, BCs, VTK) on their
+# own.
+#
+# 1D and 3D are no-ops for now: the 3D construction blends six FACE surfaces
+# rather than four edge curves, and Kopriva's Theorem 5 shows the cross-product
+# metrics do NOT satisfy the metric identities there, so it needs the curl form
+# as well and is deliberately left for its own change.
+#---------------------------------------------------------------------------------
+snap_nodes_to_exact_geometry!(mesh::St_mesh, lgl, inputs::Dict{Symbol,Any}, ::NSD_1D) = nothing
+snap_nodes_to_exact_geometry!(mesh::St_mesh, lgl, inputs::Dict{Symbol,Any}, ::NSD_3D) = nothing
+
+function snap_nodes_to_exact_geometry!(mesh::St_mesh, lgl, inputs::Dict{Symbol,Any}, ::NSD_2D)
+
+    spec = get(inputs, :exact_geometry, nothing)
+    (spec === nothing || isempty(spec)) && return nothing
+
+    comm = get_mpi_comm()
+    rank = MPI.Comm_rank(comm)
+
+    ngl = mesh.ngl
+    if ngl < 3
+        # nop = 1: the grid has no nodes other than the gmsh vertices, which
+        # already lie on the geometry. Nothing to curve.
+        println_rank(" #   :exact_geometry ignored at :nop => 1 (no high-order nodes to move).";
+                     msg_rank = rank, suppress = mesh.msg_suppress)
+        return nothing
+    end
+
+    println_rank(" # SNAP HIGH-ORDER NODES ONTO EXACT GEOMETRY ....................";
+                 msg_rank = rank, suppress = mesh.msg_suppress)
+
+    #-----------------------------------------------------------------------------
+    # Displacement field. Nonzero ONLY on the interior nodes of a curved
+    # boundary edge; the gmsh vertices keep their coordinates so that δ = 0 at
+    # every element corner, which is what makes the transfinite blend below
+    # conforming (see the header).
+    #-----------------------------------------------------------------------------
+    δx = zeros(TFloat, mesh.npoin)
+    δy = zeros(TFloat, mesh.npoin)
+    on_curved = falses(mesh.npoin)
+
+    # Sorted by tag, so every rank walks them in the same order: the circle fit
+    # below is an MPI collective and must be entered in lockstep. Keys may be
+    # written as strings or symbols in the deck; both name the same gmsh group.
+    ncurved_tags = 0
+    entries = sort!([(String(k), v) for (k, v) in spec]; by = first)
+    for (tagstr, shape_spec) in entries
+
+        edges = findall(t -> t !== nothing && String(t) == tagstr, mesh.bdy_edge_type)
+
+        # Vertices of this boundary, for the fit. Only the LINEAR ones: they are
+        # the geometry the mesh file asserts; the high-order ones are the chord
+        # interpolant we are about to correct.
+        xs = TFloat[]; ys = TFloat[]
+        for iedge in edges
+            for igl in (1, ngl)
+                ip = mesh.poin_in_bdy_edge[iedge, igl]
+                push!(xs, mesh.x[ip]); push!(ys, mesh.y[ip])
+            end
+        end
+
+        shape = _resolve_shape(tagstr, shape_spec, xs, ys, comm, rank, mesh.msg_suppress)
+        shape === nothing && continue
+
+        # A tag that exists in no .msh anywhere is a typo in the deck, not a
+        # partitioning artifact — check it globally before reporting.
+        nedges_glob = MPI.Allreduce(length(edges), MPI.SUM, comm)
+        if nedges_glob == 0
+            println_rank(string(" #   :exact_geometry \"", tagstr,
+                                "\" ignored: no boundary edge carries that tag.");
+                         msg_rank = rank, suppress = mesh.msg_suppress)
+            continue
+        end
+        ncurved_tags += 1
+
+        dmax = 0.0
+        dvert = 0.0
+        for iedge in edges
+            for igl = 1:ngl
+                ip = mesh.poin_in_bdy_edge[iedge, igl]
+                on_curved[ip] = true
+                xs_new, ys_new = snap_to_shape(shape, mesh.x[ip], mesh.y[ip])
+                if igl == 1 || igl == ngl
+                    # THE LINEAR VERTICES DO NOT MOVE. They are the element
+                    # corners, and the blend below is conforming precisely
+                    # because δ vanishes there (see the header): snapping a
+                    # corner would revive the Gordon-Hall corner terms and pull
+                    # the shared side edges of neighbouring elements apart.
+                    # gmsh already puts them on the geometry, so there is
+                    # nothing to gain — but say so if this grid does not.
+                    dvert = max(dvert, hypot(xs_new - mesh.x[ip], ys_new - mesh.y[ip]))
+                    continue
+                end
+                δx[ip] = xs_new - mesh.x[ip]
+                δy[ip] = ys_new - mesh.y[ip]
+                dmax = max(dmax, hypot(δx[ip], δy[ip]))
+            end
+        end
+
+        println_rank(string(" #   \"", tagstr, "\" -> ", shape,
+                            " ; ", nedges_glob, " edges ; largest node correction = ",
+                            MPI.Allreduce(dmax, MPI.MAX, comm));
+                     msg_rank = rank, suppress = mesh.msg_suppress)
+
+        dvert = MPI.Allreduce(dvert, MPI.MAX, comm)
+        if dvert > 1.0e-8*_shape_scale(shape)
+            println_rank(string(" #   NOTE \"", tagstr, "\": the grid's own vertices are up to ",
+                                dvert, " off that shape and are LEFT THERE (moving them would ",
+                                "break conformity with the neighbouring elements). The curved ",
+                                "boundary interpolates them, so it is that far off the shape too.");
+                         msg_rank = rank, suppress = mesh.msg_suppress)
+        end
+    end
+
+    ncurved_tags == 0 && return nothing
+
+    #-----------------------------------------------------------------------------
+    # Linear blending weights. `lgl.ξ` runs from -1 to +1, so for a curved edge
+    # sitting at index 1 of a direction the weight is 1 there and decays
+    # linearly to 0 at index ngl, and vice versa. Written as a ratio of the end
+    # values rather than (1∓ξ)/2 so it stays exact whatever the endpoint
+    # convention of the interpolation nodes is.
+    #-----------------------------------------------------------------------------
+    ξ    = TFloat.(collect(lgl.ξ[1:ngl]))
+    span = ξ[ngl] - ξ[1]
+    wlo  = TFloat[(ξ[ngl] - ξ[k])/span for k = 1:ngl]      # 1 at index 1, 0 at ngl
+    whi  = TFloat[(ξ[k] - ξ[1])/span   for k = 1:ngl]      # 0 at index 1, 1 at ngl
+
+    #-----------------------------------------------------------------------------
+    # Gordon-Hall blend into the interiors.
+    #
+    # A direction line of the element is on the curved boundary exactly when all
+    # ngl of its nodes are. It cannot be a false positive: for ngl >= 3 the
+    # interior nodes of an edge belong to that edge alone, so they are marked
+    # only if that very edge was snapped.
+    #-----------------------------------------------------------------------------
+    nelem_curved = 0
+    dmax_int     = 0.0
+    for iel = 1:mesh.nelem
+
+        jlo = true; jhi = true; ilo = true; ihi = true
+        for k = 1:ngl
+            jlo &= on_curved[mesh.connijk[iel, k, 1]]
+            jhi &= on_curved[mesh.connijk[iel, k, ngl]]
+            ilo &= on_curved[mesh.connijk[iel, 1, k]]
+            ihi &= on_curved[mesh.connijk[iel, ngl, k]]
+        end
+        (jlo || jhi || ilo || ihi) || continue
+        nelem_curved += 1
+
+        for j = 2:ngl-1, i = 2:ngl-1
+            ip = mesh.connijk[iel, i, j]
+            dx = zero(TFloat); dy = zero(TFloat)
+            if jlo
+                p = mesh.connijk[iel, i, 1];   dx += wlo[j]*δx[p]; dy += wlo[j]*δy[p]
+            end
+            if jhi
+                p = mesh.connijk[iel, i, ngl]; dx += whi[j]*δx[p]; dy += whi[j]*δy[p]
+            end
+            if ilo
+                p = mesh.connijk[iel, 1, j];   dx += wlo[i]*δx[p]; dy += wlo[i]*δy[p]
+            end
+            if ihi
+                p = mesh.connijk[iel, ngl, j]; dx += whi[i]*δx[p]; dy += whi[i]*δy[p]
+            end
+            δx[ip] = dx; δy[ip] = dy
+            dmax_int = max(dmax_int, hypot(dx, dy))
+        end
+    end
+
+    #-----------------------------------------------------------------------------
+    # Commit. One pass over everything: nodes that were never touched carry
+    # δ = 0 and so are bit-for-bit unchanged.
+    #-----------------------------------------------------------------------------
+    @inbounds for ip = 1:mesh.npoin
+        mesh.x[ip] += δx[ip]
+        mesh.y[ip] += δy[ip]
+    end
+
+    println_rank(string(" #   ", MPI.Allreduce(nelem_curved, MPI.SUM, comm),
+                        " elements curved ; largest interior node correction = ",
+                        MPI.Allreduce(dmax_int, MPI.MAX, comm));
+                 msg_rank = rank, suppress = mesh.msg_suppress)
+
+    #-----------------------------------------------------------------------------
+    # Validity. Curving a boundary on a grid that is too coarse for it — the
+    # element radially thinner than the sagitta of its own boundary arc — folds
+    # the element and produces a negative Jacobian. Catch it here, where the
+    # message can name the geometry, rather than letting it surface as a NaN
+    # thousands of time steps later.
+    #-----------------------------------------------------------------------------
+    _check_curved_elements(mesh, ξ, on_curved, comm, rank)
+
+    # The outer boundary may itself have been curved, so the bounding box that
+    # mod_mesh_read_gmsh! computed from the straight-sided grid can be stale.
+    mesh.xmax = MPI.Allreduce(maximum(mesh.x), MPI.MAX, comm)
+    mesh.xmin = MPI.Allreduce(minimum(mesh.x), MPI.MIN, comm)
+    mesh.ymax = MPI.Allreduce(maximum(mesh.y), MPI.MAX, comm)
+    mesh.ymin = MPI.Allreduce(minimum(mesh.y), MPI.MIN, comm)
+
+    return nothing
+end
+
+
+#---------------------------------------------------------------------------------
+# Jacobian sign check on the elements that were touched, using the same
+# cross-product form (Kopriva eq. 38) that build_metric_terms! will use:
+#
+#   J = X_ξ Y_η - Y_ξ X_η ,  differentiated at the nodes.
+#
+# Only the sign matters here, and it must agree with the sign the grid already
+# had — an element that flipped is a folded element.
+#---------------------------------------------------------------------------------
+function _check_curved_elements(mesh::St_mesh, ξ::AbstractVector, on_curved, comm, rank)
+
+    ngl = mesh.ngl
+    D   = lagrange_nodal_derivative_matrix(ξ)
+
+    nbad  = 0
+    ratio = Inf                          # min |J| / max |J| over curved elements
+    for iel = 1:mesh.nelem
+        touched = false
+        for k = 1:ngl
+            touched |= on_curved[mesh.connijk[iel, k, 1]]   | on_curved[mesh.connijk[iel, k, ngl]] |
+                       on_curved[mesh.connijk[iel, 1, k]]   | on_curved[mesh.connijk[iel, ngl, k]]
+        end
+        touched || continue
+
+        Jmin = Inf; Jmax = 0.0; sgn = 0
+        for j = 1:ngl, i = 1:ngl
+            xξ = 0.0; yξ = 0.0; xη = 0.0; yη = 0.0
+            for k = 1:ngl
+                p = mesh.connijk[iel, k, j]
+                xξ += D[i,k]*mesh.x[p]; yξ += D[i,k]*mesh.y[p]
+                q = mesh.connijk[iel, i, k]
+                xη += D[j,k]*mesh.x[q]; yη += D[j,k]*mesh.y[q]
+            end
+            J = xξ*yη - yξ*xη
+            s = J > 0 ? 1 : (J < 0 ? -1 : 0)
+            sgn == 0 && (sgn = s)
+            if s != sgn                                      # J changed sign inside: folded
+                nbad += 1
+                break
+            end
+            Jmin = min(Jmin, abs(J)); Jmax = max(Jmax, abs(J))
+        end
+        Jmax > 0 && (ratio = min(ratio, Jmin/Jmax))
+    end
+
+    nbad = MPI.Allreduce(nbad, MPI.SUM, comm)
+    if nbad > 0
+        error(" # ERROR exact_geometry.jl: curving the boundary folded " * string(nbad) *
+              " element(s): the Jacobian changes sign inside them.\n" *
+              " #   The grid is too coarse normal to the curved boundary for its own\n" *
+              " #   curvature. Refine the boundary layer, or drop the :exact_geometry entry.")
+    end
+    println_rank(string(" #   curved-element Jacobian check passed ; min|J|/max|J| within an element = ",
+                        MPI.Allreduce(ratio, MPI.MIN, comm));
+                 msg_rank = rank, suppress = mesh.msg_suppress)
+
+    return nothing
+end

--- a/src/kernel/mesh/mesh.jl
+++ b/src/kernel/mesh/mesh.jl
@@ -13,6 +13,7 @@ export mod_mesh_read_gmsh!
 
 include("warping.jl")
 include("stretching.jl")
+include("exact_geometry.jl")
 
 function make_extra_mesh_1D(nelem, nop, θmin, θmax, backend, inputs, lper)
     npoin = nelem*nop+1
@@ -3663,6 +3664,16 @@ function mod_mesh_read_gmsh!(mesh::St_mesh, inputs::Dict{Symbol,Any}, nparts::In
     #----------------------------------------------------------------------
     # END Extract boundary edges and faces nodes
     #----------------------------------------------------------------------
+
+    # The high-order nodes were interpolated on the STRAIGHT-SIDED element, so
+    # a boundary that the .geo defined as a curve (a gmsh `Circle`, say) is a
+    # polygon as far as the solver is concerned, however large :nop is. Where
+    # the case deck names the exact geometry, snap the boundary nodes onto it
+    # and blend the correction into the element interiors. This is the 2D
+    # counterpart of project_nodes_to_shell! above; it needs the boundary-edge
+    # tables and connijk, which is why it runs here and not up with the
+    # add_high_order_nodes_* calls. No-op unless :exact_geometry is set.
+    snap_nodes_to_exact_geometry!(mesh, lgl, inputs, mesh.SD)
 
     if (inputs[:extra_dimensions] > 0)
         println(" # constructing extra grids for extra dimensions ...................... IN PROGRESS")

--- a/src/kernel/mesh/metric_terms.jl
+++ b/src/kernel/mesh/metric_terms.jl
@@ -257,36 +257,42 @@ function build_metric_terms!(metrics, mesh::St_mesh, basis::St_Lagrange, N, Q, �
             end
         end
         
-        # Optimize boundary edge calculations
+        # Boundary-edge surface Jacobian and unit normal.
+        #
+        # Both come from the tangent of the SAME degree-N interpolant that the
+        # volume metrics above differentiate: t(ξ_k) = Σ_i ℓ_i'(ξ_k) X_i, so
+        # Jef = |t| (which is what compute_segment_integral! multiplies ω by)
+        # and n = (t_y, -t_x)/|t|, signed outward below.
+        #
+        # On a straight edge the interpolant is linear, so this reproduces the
+        # chord/2 and the exact normal it replaces, to round-off. On an edge
+        # curved by snap_nodes_to_exact_geometry! it is the only version that
+        # is right: a chord length is constant along an arc when |dX/dξ| is
+        # not, and a two-point difference gets the wall normal wrong by O(h) —
+        # which would throw away most of what curving the boundary buys.
+        Dedge = lagrange_nodal_derivative_matrix(collect(TFloat.(@view ξ[1:N+1])))
+
         nbdy_edges = size(mesh.poin_in_bdy_edge, 1)
         @inbounds for iedge = 1:nbdy_edges
             poin_edge = @view mesh.poin_in_bdy_edge[iedge, :]
-            
-            # Pre-compute edge endpoints for Jef calculation
-            ip_first = poin_edge[1]
-            ip_last = poin_edge[N+1]
-            edge_length = sqrt((mesh.x[ip_first] - mesh.x[ip_last])^2 + 
-                (mesh.y[ip_first] - mesh.y[ip_last])^2)
-            Jef_val = edge_length * 0.5  # Avoid division by 2
-            
+
             for k = 1:N+1
+                # Tangent dX/dξ at edge node k
+                tx = zero(TFloat); ty = zero(TFloat)
+                for i = 1:N+1
+                    ipi = poin_edge[i]
+                    tx += Dedge[k,i]*mesh.x[ipi]
+                    ty += Dedge[k,i]*mesh.y[ipi]
+                end
+
                 ip = poin_edge[k]
-                
-                # Determine next/previous point more efficiently
-                ip1 = (k < N+1) ? poin_edge[k+1] : poin_edge[k-1]
-                
-                # Cache coordinates
-                x1, y1 = mesh.x[ip], mesh.y[ip]
-                x2, y2 = mesh.x[ip1], mesh.y[ip1]
-                
-                # Compute normal vector components
-                dx, dy = x1 - x2, y1 - y2
-                mag_inv = 1.0 / sqrt(dx*dx + dy*dy)  # Use single sqrt and invert
-                
+                mag = sqrt(tx*tx + ty*ty)
+                mag_inv = T(1.0)/mag
+
                 # Store results
-                metrics.Jef[iedge, k] = Jef_val
-                metrics.nx[iedge, k] = dy * mag_inv
-                metrics.ny[iedge, k] = -dx * mag_inv
+                metrics.Jef[iedge, k] = mag
+                metrics.nx[iedge, k] = ty * mag_inv
+                metrics.ny[iedge, k] = -tx * mag_inv
                 e = mesh.bdy_edge_in_elem[iedge]
                 ip2 = mesh.connijk[e,2,2]
                 idx1 = 0
@@ -324,6 +330,13 @@ function build_metric_terms!(metrics, mesh::St_mesh, basis::St_Lagrange, N, Q, �
         nbdy_edges    = size(mesh.poin_in_bdy_edge,1)
         poin_in_bdy_edge = KernelAbstractions.allocate(backend, TInt, Int64(nbdy_edges), N+1)
         KernelAbstractions.copyto!(backend, poin_in_bdy_edge,mesh.poin_in_bdy_edge)
+        # NOTE the GPU boundary kernel has NOT been given the tangent-based Jef
+        # and normal that the CPU branch above now uses, so it is not
+        # curved-boundary aware: on a wall curved by :exact_geometry it still
+        # returns a two-point normal (O(h) off the geometry's own) and a Jef
+        # that is not |dX/dξ|. Deliberately left for its own change — it also
+        # disagrees with the CPU path on STRAIGHT edges, which is a separate
+        # pre-existing bug, and there is no GPU here to verify a fix on.
         k = build_2D_gpu_bdy_metrics!(backend)
         k(metrics.Jef, metrics.nx, metrics.ny, x, y, poin_in_bdy_edge, N; ndrange = (nbdy_edges*(N+1)), workgroupsize = (N+1))
     end

--- a/submit_jexpresso_profile.sh
+++ b/submit_jexpresso_profile.sh
@@ -1,0 +1,310 @@
+#!/bin/bash
+#=============================================================================
+#  Jexpresso profile run.
+#
+#      sbatch submit_Jexpresso_profile.sh
+#
+#  NO ARGUMENTS. Which stage solve runs is the DECK's business, not this
+#  file's: it is `use_imex` / `use_schur` in the case's user_inputs.jl, both
+#  on by default. On the 64x64x60 decks `use_schur = !_vdiff`, so DBG_VDIFF=0
+#  is what selects the Schur arm (with explicit vertical diffusion).
+#  This script sets resources and runs the case.
+#
+#  EDIT THE TWO BLOCKS MARKED "EDIT ME". Nothing else in this file needs
+#  changing to run a different problem, on a different rank count, on a
+#  different cluster.
+#
+#  For a one-off A/B without editing the deck, set the variable in the
+#  environment and it is passed through:
+#
+#      DBG_SCHUR=0 sbatch submit_Jexpresso_profile.sh     # five-field arm
+#
+#  WHAT STILL GUARDS THE A/B. This used to demand `schur` or `full` as an
+#  argument so that a forgotten word could not silently run the wrong arm. The
+#  guard is not lost by dropping it: the ranks print which stage solve they
+#  built, from inside the run --
+#
+#      Stage solve: preconditioned GMRES on the SCALAR SCHUR system
+#      Stage solve: preconditioned GMRES on all 5 fields
+#
+#  -- and that line, not anything this script echoes, is the authoritative
+#  record of what was measured.
+#=============================================================================
+
+#--------------------------------------------------------------- EDIT ME (1) -
+#  RESOURCES.  nodes x ntasks-per-node = your MPI RANK COUNT.
+#
+#  DO NOT pick a rank count freely. With :lxy_partition the mesh is cut into
+#  vertical columns, so the usable parallelism is bounded by nelemx*nelemy and
+#  anything else leaves ranks owning zero elements (fatal). Ask first:
+#
+#      julia tools/pick_nranks.jl <nelemx> <nelemy> <nelemz> <nop> <max_cores>
+#
+#  Answers for the cases here:
+#      LESICP2-64x64x60-imex   256  (16 x 16 over 64 x 64 columns)  <- set below
+#      rtb3d_schur              25  (5 x 5 over 20 x 20)
+#      rtb2d_schur               4  (a slab has only 20 columns)
+#
+#  cpus-per-task BUYS MEMORY, NOT SPEED. This is pure MPI -- the job exports
+#  JULIA_NUM_THREADS=1 -- so the second core per task sits idle and its only
+#  effect is that each rank gets mem-per-cpu x cpus-per-task. 64 x 2 = 128
+#  fills a Wulver node; 3500M x 2 = 7000M/rank is what setup_les_run.sh found
+#  this domain needs, and 64 x 7000M = 448 GB/node leaves the node headroom.
+#-----------------------------------------------------------------------------
+#SBATCH --nodes=4
+#SBATCH --ntasks-per-node=64
+#SBATCH --cpus-per-task=2
+# 71:59:00, not 2 hours. At dt = 0.5 the deck's tend of 10800 s is 21,600 steps
+# and the measured rate is ~3.7 s/step, i.e. around 22 h -- a 2 h limit killed
+# it about 9% in. Drop this back to something short only for a TEND-limited
+# probe run.
+#SBATCH --time=71:59:00
+#SBATCH --mem-per-cpu=3500M
+#
+#  Site settings -- set once for your cluster, then forget.
+#SBATCH --partition=general
+#SBATCH --qos=standard
+#SBATCH --account=smarras
+#SBATCH --job-name=jexpresso
+#SBATCH --output=%x.%j.out
+#SBATCH --error=%x.%j.err
+
+#--------------------------------------------------------------- EDIT ME (2) -
+#  WHAT TO RUN.
+#-----------------------------------------------------------------------------
+EQS="CompEuler"
+CASE="LESICP2-64x64x60-imex"
+#CASE="LESICP2-64x64x60-dynsgs"
+TEND="10800.0"
+MESH=""
+ROOT="/project/smarras/smarras/Jexpresso"
+MODULES=(Julia/1.11.9 GCC MPICH)
+
+#=============================================================================
+#  Nothing below here needs editing.
+#=============================================================================
+set -u
+
+# An argument is no longer accepted. Refuse one rather than ignore it: a
+# leftover `sbatch ... schur` from muscle memory should not look like it did
+# something.
+if [ $# -gt 0 ]; then
+    echo "ERROR: this script takes no arguments (got '$1')." >&2
+    echo "       Which stage solve runs is set in the deck --" >&2
+    echo "       use_imex / use_schur in problems/$EQS/$CASE/user_inputs.jl," >&2
+    echo "       default. For a one-off five-field run:" >&2
+    echo "           DBG_SCHUR=0 sbatch $(basename "$0")" >&2
+    exit 2
+fi
+
+for m in "${MODULES[@]}"; do module load "$m" || exit 1; done
+cd "$ROOT" || exit 1
+
+#-- 2. deck settings, passed through the environment ----------------------
+# DBG_SCHUR is NOT set here -- the deck owns it. Passed through only when the
+# caller put it in the environment, on the same terms as rtol/restart/maxiter
+# below.
+[ -n "${DBG_SCHUR:-}" ] && export DBG_SCHUR
+# DBG_VDIFF picks the IMEX ARM on the LESICP2 64x64x60 decks: the deck sets
+# `use_schur = !_vdiff`, so DBG_VDIFF=0 is what selects the Schur stage solve
+# with EXPLICIT vertical diffusion. Without this line a caller's DBG_VDIFF is a
+# plain shell variable that never reaches Julia, the deck keeps its default,
+# and the run silently takes the other arm.
+[ -n "${DBG_VDIFF:-}" ]   && export DBG_VDIFF
+[ -n "${DBG_FILTER:-}" ]  && export DBG_FILTER
+[ -n "${DBG_SCHEME:-}" ]  && export DBG_SCHEME
+# `${DBG_TEND:-$TEND}`, not `$TEND`: a bare assignment here OVERRODE the
+# caller, so `DBG_TEND=5 sbatch ...` silently ran the deck's full tend. The
+# EDIT ME value is the default; the environment wins, as it does for DBG_SCHUR
+# and the Krylov knobs below.
+export DBG_TEND="${DBG_TEND:-$TEND}"
+[ -n "${DBG_MESH:-$MESH}" ] && export DBG_MESH="${DBG_MESH:-$MESH}"
+# THE LAUNCHER DOES NOT SET rtol OR restart. It used to default them to 1.0e-8
+# and 20 -- the rtb values -- which silently OVERRODE any deck with its own
+# tuning. LESICP2 ships 1.0e-6 and 30 for a reason (it runs at CFL_h 2.77), and
+# a launcher quietly imposing a 100x tighter tolerance at a shorter restart is
+# how a case that converges becomes a case that does not. Pass them only when
+# the user asked for them; otherwise the deck decides.
+[ -n "${DBG_RTOL:-}" ]    && export DBG_RTOL
+[ -n "${DBG_RESTART:-}" ] && export DBG_RESTART
+[ -n "${DBG_MAXITER:-}" ] && export DBG_MAXITER
+
+# `:-` on all three: bare assignments clobbered the caller, so
+# JEXPRESSO_HEVI_PROFILE_EVERY=1 on the sbatch line was ignored and the
+# breakdown still came every 50 steps. Same rule as DBG_TEND and DBG_VDIFF --
+# the value here is the default, the environment wins.
+export JEXPRESSO_HEVI_PROFILE="${JEXPRESSO_HEVI_PROFILE:-1}"
+export JEXPRESSO_HEVI_PROFILE_EVERY="${JEXPRESSO_HEVI_PROFILE_EVERY:-50}"
+export JEXPRESSO_HEVI_PROFILE_SKIP="${JEXPRESSO_HEVI_PROFILE_SKIP:-10}"
+export JEXPRESSO_PRECOMPILE_PASS="${JEXPRESSO_PRECOMPILE_PASS:-1}"
+export JEXPRESSO_STEP_HEARTBEAT=1
+# THE SCHUR ARM IS THIS SCRIPT'S DEFAULT: explicit vertical diffusion, so
+# `use_schur = !_vdiff` in the deck leaves the scalar Schur stage solve on.
+# `:-0` rather than a bare 0 so `DBG_VDIFF=1 sbatch ...` still reaches the deck
+# -- a launcher that overrides the caller's environment is how an A/B silently
+# measures the same arm twice.
+export DBG_VDIFF="${DBG_VDIFF:-0}"
+
+# One BLAS/Julia thread per rank: the ranks already fill the node, and nested
+# threading oversubscribes it.
+export JULIA_NUM_THREADS=1 OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1
+
+#-- 3. serial setup, before any rank is launched --------------------------
+# Each step here fails cheaply and says why. Compiling inside the parallel
+# launch instead means every rank compiles the same code at once.
+export JULIA_PKG_PRECOMPILE_AUTO=1
+
+echo "--- MPI preferences (must precede any compilation) ---"
+julia --project=. --startup-file=no \
+    -e 'using MPIPreferences; MPIPreferences.use_system_binary()' || exit 1
+
+echo "--- Syntax check (seconds, before paying minutes for a precompile) ---"
+julia --startup-file=no tools/syntax_check.jl src test problems tools || {
+    echo "ERROR: syntax error in the source tree. Nothing compiled, no ranks launched." >&2
+    exit 1; }
+
+echo "--- Precompile ---"
+julia --project=. --startup-file=no -e 'using Pkg; Pkg.instantiate(); Pkg.precompile()' || exit 1
+
+echo "--- Serial load (exercises the real load path) ---"
+julia --project=. --startup-file=no -e '
+    t = @elapsed (using MPI; using Jexpresso)
+    println("    Jexpresso loaded in ", round(t, digits=2), " s")' || {
+    echo "ERROR: Jexpresso failed to load serially. Fix that before launching ranks." >&2
+    exit 1; }
+
+export JULIA_PKG_PRECOMPILE_AUTO=0 JULIA_NUM_PRECOMPILE_TASKS=1
+
+#-- 4. julia flags --------------------------------------------------------
+JULIA_FLAGS=(--project=. --startup-file=no)
+julia --compiled-modules=existing -e 'exit(0)' >/dev/null 2>&1 && JULIA_FLAGS+=(--compiled-modules=existing)
+julia --pkgimages=existing       -e 'exit(0)' >/dev/null 2>&1 && JULIA_FLAGS+=(--pkgimages=existing)
+
+# Julia sizes its heap from /proc/meminfo, i.e. the whole NODE, not the cgroup
+# this job actually gets -- so without a hint it happily grows past the limit
+# and is OOM-killed with no Julia-level error.
+if [ -n "${SLURM_MEM_PER_CPU:-}" ]; then
+    RANK_MB=$(( SLURM_MEM_PER_CPU * ${SLURM_CPUS_PER_TASK:-1} ))
+elif [ -n "${SLURM_MEM_PER_NODE:-}" ] && [ -n "${SLURM_NTASKS_PER_NODE:-}" ]; then
+    RANK_MB=$(( SLURM_MEM_PER_NODE / SLURM_NTASKS_PER_NODE ))
+else
+    RANK_MB=0
+fi
+HEAP_MB=0
+if [ "$RANK_MB" -gt 0 ] && julia --heap-size-hint=1G -e 'exit(0)' >/dev/null 2>&1; then
+    HEAP_MB=$(( RANK_MB * 85 / 100 ))
+    JULIA_FLAGS+=(--heap-size-hint=${HEAP_MB}M)
+fi
+
+#-- 5. launcher -----------------------------------------------------------
+NTASKS="${SLURM_NTASKS:-1}"
+NNODES="${SLURM_NNODES:-1}"
+
+# srun rejects a job that carries both, and this one is sized per CPU.
+if [ -n "${SLURM_MEM_PER_CPU:-}" ] && [ -n "${SLURM_MEM_PER_NODE:-}" ]; then
+    echo "    (unsetting SLURM_MEM_PER_NODE: srun treats it as exclusive with _PER_CPU)"
+    unset SLURM_MEM_PER_NODE
+fi
+
+SRUN_MPI="${SRUN_MPI:-pmi2}"
+if [ -n "${JEXPRESSO_LAUNCHER:-}" ]; then LAUNCHER="$JEXPRESSO_LAUNCHER"
+elif [ "$NNODES" -gt 1 ] && command -v srun >/dev/null 2>&1; then LAUNCHER="srun"
+else LAUNCHER="mpirun"; fi
+
+launch() {
+    if [ "$LAUNCHER" = "srun" ]; then
+        srun --mpi="$SRUN_MPI" -n "$NTASKS" -c "${SLURM_CPUS_PER_TASK:-1}" julia "$@"
+    else
+        mpirun -np "$NTASKS" julia "$@"
+    fi
+}
+
+#-- 6. preflight: can MPI actually run these ranks? -----------------------
+# A launcher that gives every process a COMM_WORLD of size 1 produces N
+# independent serial runs writing over each other, which looks like a slow
+# success. Catch it before the mesh read.
+export JEXPRESSO_EXPECT_RANKS="$NTASKS"
+echo "--- Preflight: MPI_Init_thread + one Allreduce on $NTASKS ranks ---"
+launch "${JULIA_FLAGS[@]}" -e '
+    using MPI; MPI.Init()
+    c = MPI.COMM_WORLD; n = MPI.Comm_size(c); r = MPI.Comm_rank(c)
+    s = MPI.Allreduce(1, MPI.SUM, c)
+    want = parse(Int, ENV["JEXPRESSO_EXPECT_RANKS"])
+    ok = (n == want) && (s == n)
+    r == 0 && println("    MPI ", ok ? "OK" : "**BROKEN**", ": Comm_size = ", n,
+                      " (asked for ", want, "), Allreduce(1) = ", s)
+    MPI.Barrier(c); MPI.Finalize(); exit(ok ? 0 : 1)' || {
+    rc=$?
+    echo "ERROR: MPI cannot run $NTASKS ranks across $NNODES nodes (exit $rc)." >&2
+    echo "       Nothing in Jexpresso has run. If Comm_size came back 1, it is the" >&2
+    echo "       PMI plugin: try another SRUN_MPI (srun --mpi=list). If it came" >&2
+    echo "       back wrong-but-not-1, the allocation and the launch disagree." >&2
+    echo "       Single node failing too means it is not the network: check /dev/shm" >&2
+    echo "       and that --mem-per-cpu x --ntasks-per-node fits the node." >&2
+    exit $rc; }
+
+#-- 7. run ----------------------------------------------------------------
+# This shell cannot know what the deck chose, so it does not pretend to: it
+# reports an override if one was given and defers otherwise. The ranks' own
+# setup report is the authoritative line -- see the header.
+case "${DBG_SCHUR:-}" in
+    1) arm_desc="SCALAR Schur, Np unknowns   (forced by DBG_SCHUR=1)" ;;
+    0) arm_desc="five-field, 5*Np unknowns   (forced by DBG_SCHUR=0)" ;;
+    *) case "${DBG_VDIFF:-}" in
+           # On the 64x64x60 decks use_schur = !_vdiff, so DBG_VDIFF settles it
+           # when DBG_SCHUR is not given. Other decks ignore DBG_VDIFF, hence
+           # "expected" rather than a claim.
+           0) arm_desc="SCALAR Schur, Np unknowns   (expected: DBG_VDIFF=0, explicit diffusion)" ;;
+           1) arm_desc="five-field, 5*Np unknowns   (expected: DBG_VDIFF=1, implicit diffusion)" ;;
+           *) arm_desc="<deck decides -- see 'Stage solve:' in the run's own output>" ;;
+       esac ;;
+esac
+
+echo "--- Launching $NTASKS ranks ---"
+echo "    case          : $EQS / $CASE${MESH:+  (mesh $MESH)}"
+echo "    stage solve   : $arm_desc"
+echo "    resources     : $NNODES node(s) x $((NTASKS / NNODES)) tasks x ${SLURM_CPUS_PER_TASK:-1} cpus"
+[ "$LAUNCHER" = srun ] && LAUNCHER_DESC="srun --mpi=$SRUN_MPI" || LAUNCHER_DESC="mpirun"
+echo "    launcher      : $LAUNCHER_DESC"
+if [ "$HEAP_MB" -gt 0 ]; then
+    echo "    memory/rank   : ${RANK_MB} MB budget, --heap-size-hint=${HEAP_MB}M"
+else
+    echo "    memory/rank   : no heap hint set -- Julia sizes its heap from the whole"
+    echo "                    node and can be OOM-killed against a smaller cgroup"
+fi
+echo "    tend / rtol   : ${DBG_TEND:-<deck>} s / ${DBG_RTOL:-<deck>}, restart ${DBG_RESTART:-<deck>}, maxiter ${DBG_MAXITER:-<deck>}"
+echo "    vert. diff    : ${DBG_VDIFF:+DBG_VDIFF=}${DBG_VDIFF:-<deck>}"
+# Print the diagnostic switches the ranks will actually see. A monitor that
+# does not fire is otherwise indistinguishable from a variable that never
+# arrived, and that ambiguity has cost a debugging cycle already.
+echo "    diagnostics   : DSGS_MONITOR=${JEXPRESSO_DSGS_MONITOR:-0}  HEVI_PROFILE=${JEXPRESSO_HEVI_PROFILE:-0} every ${JEXPRESSO_HEVI_PROFILE_EVERY}/skip ${JEXPRESSO_HEVI_PROFILE_SKIP}  imex_monitor_every=${DBG_IMEXMONEVERY:-<deck>}"
+echo "    started       : $(date)"
+echo
+# The banner above is printed from THIS shell. The authoritative statement of
+# which arm the ranks ran is in their own setup report:
+#     "Stage solve: preconditioned GMRES on the SCALAR SCHUR system"
+#     "    matvec: bespoke scalar sweeps ..."
+# versus "... on all 5 fields". Read that, not this.
+
+launch "${JULIA_FLAGS[@]}" src/Jexpresso.jl "$EQS" "$CASE"
+rc=$?
+echo "--- Finished: $(date) ---"
+
+#-- 8. report the exit status ---------------------------------------------
+# Write with plain echo / >&2, NEVER "> /dev/stdout": under SLURM those are
+# regular files and re-opening them truncates the whole job log.
+if [ "$rc" -ne 0 ]; then
+    log="${SLURM_JOB_NAME:-job}.${SLURM_JOB_ID:-0}.out"
+    _report() {
+        echo "--- FAILED: launcher exited $rc ---"
+        echo "    Julia's error and backtrace are ABOVE this line, in the .err for"
+        echo "    job ${SLURM_JOB_ID:-<id>}."
+        if [ -f "$log" ] && grep -q "Min elements: 0" "$log"; then
+            echo "    'Min elements: 0' in this run: some ranks own no elements."
+            echo "    The rank count exceeds what this mesh can be split into --"
+            echo "    ask tools/pick_nranks.jl and use a count it lists."
+        fi
+    }
+    _report; _report >&2
+fi
+exit $rc

--- a/test/test_exact_geometry.jl
+++ b/test/test_exact_geometry.jl
@@ -1,0 +1,478 @@
+#---------------------------------------------------------------------------------
+# test/test_exact_geometry.jl — 2D curved-boundary snapping
+# (src/kernel/mesh/exact_geometry.jl).
+#
+#   julia test/test_exact_geometry.jl
+#
+# NO `using Jexpresso`. Like test_cubed_sphere_maps.jl, this includes the source
+# directly; the handful of names exact_geometry.jl borrows from the package
+# (TFloat, MPI, println_rank, St_mesh, NSD_*) are stubbed below, so the numerics
+# stay checkable without building a 130-package environment. The stub St_mesh
+# carries exactly the fields the routine touches — if it grows a dependency on
+# another field, this file stops compiling, which is the intended alarm.
+#
+# The grid under test is an annulus of nr x nt quads around a circle of radius
+# R: the shock_circle topology in miniature, built STRAIGHT-SIDED the way
+# mod_mesh_read_gmsh! builds one (linear vertices on the circle, LGL nodes
+# interpolated on the straight quad), so the "before" state is exactly what the
+# solver would otherwise see, and the exact answer is known in closed form.
+#
+# What is being pinned down, in the order it matters:
+#
+#   1. THE GRID STAYS CONFORMING. This is the property the whole construction is
+#      arranged around and the one whose failure would be silent and fatal: a
+#      node is shared between elements, so if the curving moved a node that a
+#      NON-curved neighbour also owns, the two elements would disagree about
+#      where their shared edge is and the DSS would be summing values at
+#      different points. It cannot happen here because the transfinite blend of
+#      an edge displacement vanishes identically on the two edges adjacent to
+#      that edge — which is only true because the element corners (the linear
+#      gmsh vertices) are left exactly where they were. Asserted directly:
+#      every node of every element that does not touch the circle is bit-for-bit
+#      unmoved.
+#
+#   2. THE ELEMENTS DO NOT FOLD. Curving a boundary on a grid too coarse normal
+#      to it turns the element inside out. The Jacobian is checked over the
+#      whole grid with the same cross-product form build_metric_terms! uses.
+#
+#   3. FREE-STREAM PRESERVATION SURVIVES. Kopriva (2006) Theorem 3: in 2D the
+#      cross-product metrics satisfy the discrete metric identities iff the
+#      mapping is in P^N. Curving moves nodes, and the mapping is the degree-N
+#      interpolant through them, so it stays in P^N — but that is an argument,
+#      and this is the measurement. Form II of the DMIs, eq. (30), is evaluated
+#      before and after and must sit at round-off both times.
+#
+#   4. THE BOUNDARY IS ACTUALLY THE CIRCLE NOW. Not just at the nodes (that is
+#      trivially true after a projection) but BETWEEN them: the degree-N
+#      interpolant through the snapped edge nodes is sampled densely and its
+#      distance from the true circle measured. Straight-sided converges at
+#      O(h²) and stops there however large :nop is — that is the defect being
+#      fixed. Isoparametric degree-N edges converge at O(h^{N+1}) or better.
+#
+#   5. THE CURVED-EDGE SURFACE METRICS. build_metric_terms!(…, NSD_2D) gets Jef
+#      and the wall normal from the edge tangent of the same interpolant. On a
+#      straight edge that must reproduce, to round-off, the chord/2 and the
+#      two-point normal it replaces (this is what makes the change a no-op for
+#      every existing case); on the curved edge it must give the exact circle
+#      normal, which the two-point difference does not.
+#
+#   6. The circle fit accepts a circle and REFUSES a straight boundary. The fit
+#      is what runs when a deck writes `:circle` without coordinates, and a
+#      silent bad fit would deform the grid onto a shape nobody asked for.
+#---------------------------------------------------------------------------------
+
+using Test
+using LinearAlgebra
+using Printf
+
+#---------------------------------------------------------------------------------
+# Package stubs — the whole of what exact_geometry.jl borrows from Jexpresso.
+#---------------------------------------------------------------------------------
+const TFloat = Float64
+const TInt   = Int64
+
+module MPI                                  # serial stand-in: Allreduce is identity
+    struct Op; f::Function; end
+    const SUM = Op(+); const MIN = Op(min); const MAX = Op(max)
+    Comm_rank(c) = 0
+    Allreduce(x, ::Op, c) = x
+end
+get_mpi_comm() = nothing
+println_rank(args...; msg_rank = 0, suppress = false) = nothing
+
+struct NSD_1D end
+struct NSD_2D end
+struct NSD_3D end
+
+mutable struct St_mesh
+    nsd::Int; nop::Int; ngl::Int
+    npoin::Int; nelem::Int; nedges_bdy::Int
+    x::Vector{Float64}; y::Vector{Float64}
+    connijk::Array{Int,3}
+    poin_in_bdy_edge::Array{Int,2}
+    bdy_edge_type::Vector{Union{Nothing,String}}
+    bdy_edge_in_elem::Vector{Int}
+    SD::Any
+    msg_suppress::Bool
+    xmin::Float64; xmax::Float64; ymin::Float64; ymax::Float64
+end
+
+include(joinpath(@__DIR__, "..", "src", "kernel", "mesh", "exact_geometry.jl"))
+
+
+#---------------------------------------------------------------------------------
+# Legendre-Gauss-Lobatto nodes on [-1,1]: Newton on (1-x²)P'_N, started from the
+# Chebyshev-Lobatto points. Same nodes basis_structs_ξ_ω! produces for "lgl".
+#---------------------------------------------------------------------------------
+function lgl_nodes(N::Int)
+    N == 1 && return [-1.0, 1.0]
+    x    = [-cos(pi*i/N) for i = 0:N]
+    P    = zeros(N+1, N+1)
+    xold = 2 .* x
+    while maximum(abs.(x .- xold)) > 1.0e-15
+        xold = copy(x)
+        P[:,1] .= 1.0; P[:,2] .= x
+        for k = 2:N
+            @. P[:,k+1] = ((2k-1)*x*P[:,k] - (k-1)*P[:,k-1])/k
+        end
+        @. x = xold - (x*P[:,N+1] - P[:,N])/((N+1)*P[:,N+1])
+    end
+    x[1] = -1.0; x[end] = 1.0
+    return x
+end
+
+# LGL quadrature weights, w_k = 2/(N(N+1) P_N(ξ_k)²).
+function lgl_weights(N::Int)
+    ξ = lgl_nodes(N)
+    P = ones(N+1); Pm = zeros(N+1)
+    for k = 1:N
+        P, Pm = ((2k-1) .* ξ .* P .- (k-1) .* Pm) ./ k, P
+    end
+    return 2.0 ./ (N*(N+1) .* P.^2)
+end
+
+struct LGL; ξ::Vector{Float64}; end
+
+const R, XC, YC = 0.2, 1.0, 0.0             # the circle every test below uses
+
+#---------------------------------------------------------------------------------
+# Straight-sided annulus of nr x nt quads, R <= r <= Rout, inner ring of edges
+# tagged "circle". Index i runs radially (i == 1 on the circle), j azimuthally.
+#---------------------------------------------------------------------------------
+function build_annulus(N, nr, nt; Rout = 0.6)
+    ngl = N + 1
+    ξ   = lgl_nodes(N)
+    id  = Dict{NTuple{2,Int},Int}()
+    xs  = Float64[]; ys = Float64[]
+    function push_node!(x, y)                    # de-duplicate shared nodes
+        k = (round(Int, x/1.0e-12), round(Int, y/1.0e-12))
+        haskey(id, k) && return id[k]
+        push!(xs, x); push!(ys, y); id[k] = length(xs); return length(xs)
+    end
+
+    connijk = zeros(Int, nr*nt, ngl, ngl)
+    bdy_p   = Int[]; bdy_e = Int[]
+    rv(a) = R + (Rout - R)*a/nr
+    θv(b) = 2pi*b/nt
+
+    iel = 0
+    for a = 0:nr-1, b = 0:nt-1
+        iel += 1
+        V = ntuple(4) do c
+            (ra, tb) = ((a, b), (a+1, b), (a+1, b+1), (a, b+1))[c]
+            (XC + rv(ra)*cos(θv(tb)), YC + rv(ra)*sin(θv(tb)))
+        end
+        for j = 1:ngl, i = 1:ngl                 # bilinear on the straight quad
+            u = (ξ[i] + 1)/2; v = (ξ[j] + 1)/2
+            x = (1-u)*(1-v)*V[1][1] + u*(1-v)*V[2][1] + u*v*V[3][1] + (1-u)*v*V[4][1]
+            y = (1-u)*(1-v)*V[1][2] + u*(1-v)*V[2][2] + u*v*V[3][2] + (1-u)*v*V[4][2]
+            connijk[iel, i, j] = push_node!(x, y)
+        end
+        if a == 0
+            push!(bdy_e, iel)
+            append!(bdy_p, [connijk[iel, 1, j] for j = 1:ngl])
+        end
+    end
+
+    nbdy = length(bdy_e)
+    mesh = St_mesh(2, N, ngl, length(xs), nr*nt, nbdy, xs, ys, connijk,
+                   collect(reshape(bdy_p, ngl, nbdy)'),
+                   Union{Nothing,String}["circle" for _ = 1:nbdy], bdy_e,
+                   NSD_2D(), true,
+                   minimum(xs), maximum(xs), minimum(ys), maximum(ys))
+    return mesh, LGL(ξ)
+end
+
+curve!(mesh, lgl; shape = :circle) =
+    snap_nodes_to_exact_geometry!(mesh, lgl,
+        Dict{Symbol,Any}(:exact_geometry => Dict("circle" => shape)), mesh.SD)
+
+# Metrics of one element exactly as build_metric_terms!(…, NSD_2D) forms them:
+# by differentiating the degree-N nodal interpolant. Kopriva eq. (38).
+function element_metrics(mesh, iel, D)
+    ngl = mesh.ngl
+    Ja1 = zeros(2, ngl, ngl); Ja2 = zeros(2, ngl, ngl); J = zeros(ngl, ngl)
+    for j = 1:ngl, i = 1:ngl
+        xξ = yξ = xη = yη = 0.0
+        for k = 1:ngl
+            p = mesh.connijk[iel, k, j]; xξ += D[i,k]*mesh.x[p]; yξ += D[i,k]*mesh.y[p]
+            q = mesh.connijk[iel, i, k]; xη += D[j,k]*mesh.x[q]; yη += D[j,k]*mesh.y[q]
+        end
+        Ja1[1,i,j] =  yη; Ja1[2,i,j] = -xη
+        Ja2[1,i,j] = -yξ; Ja2[2,i,j] =  xξ
+        J[i,j] = xξ*yη - yξ*xη
+    end
+    return J, Ja1, Ja2
+end
+
+# Form II of the discrete metric identities, Kopriva eq. (30), normalised by the
+# size of the metric terms so the number is dimensionless.
+function dmi_residual(mesh, D)
+    ngl = mesh.ngl; worst = 0.0; scale = 0.0
+    for iel = 1:mesh.nelem
+        _, Ja1, Ja2 = element_metrics(mesh, iel, D)
+        scale = max(scale, maximum(abs, Ja1) + maximum(abs, Ja2))
+        for n = 1:2, j = 1:ngl, i = 1:ngl
+            s = 0.0
+            for k = 1:ngl
+                s += D[i,k]*Ja1[n,k,j] + D[j,k]*Ja2[n,i,k]
+            end
+            worst = max(worst, abs(s))
+        end
+    end
+    return worst/scale
+end
+
+# Barycentric evaluation of the degree-N interpolant through (px, py) at ξ = s.
+function eval_edge(ξ, px, py, s)
+    n = length(ξ)
+    for k = 1:n
+        abs(s - ξ[k]) < 1.0e-14 && return (px[k], py[k])
+    end
+    X = Y = W = 0.0
+    for k = 1:n
+        w = 1.0
+        for j = 1:n; j == k || (w /= (ξ[k] - ξ[j])); end
+        w /= (s - ξ[k])
+        X += w*px[k]; Y += w*py[k]; W += w
+    end
+    return (X/W, Y/W)
+end
+
+# Sup distance between the discrete boundary and the true circle.
+function boundary_error(N, nt; curved, nr = 2)
+    m, l = build_annulus(N, nr, nt)
+    curved && curve!(m, l)
+    worst = 0.0
+    for ie = 1:m.nedges_bdy
+        px = [m.x[m.poin_in_bdy_edge[ie,k]] for k = 1:m.ngl]
+        py = [m.y[m.poin_in_bdy_edge[ie,k]] for k = 1:m.ngl]
+        for s in range(-1, 1; length = 201)
+            X, Y = eval_edge(l.ξ, px, py, s)
+            worst = max(worst, abs(hypot(X - XC, Y - YC) - R))
+        end
+    end
+    return worst
+end
+
+
+@testset verbose = true "exact geometry (2D curved boundaries)" begin
+
+    @testset "nodal derivative matrix" begin
+        for N in (2, 4, 7)
+            ξ = lgl_nodes(N); D = lagrange_nodal_derivative_matrix(ξ)
+            @test maximum(abs, D*ones(N+1))           < 1.0e-12         # d/dξ const
+            @test maximum(abs, D*ξ .- 1.0)            < 1.0e-12         # d/dξ ξ
+            # exact for every polynomial of degree <= N, and only those
+            N >= 3 && @test maximum(abs, D*(ξ.^3) .- 3 .* ξ.^2) < 1.0e-11
+        end
+    end
+
+    @testset "circle fit" begin
+        m, _ = build_annulus(4, 2, 16)
+        xs = Float64[]; ys = Float64[]
+        for ie = 1:m.nedges_bdy, ig in (1, m.ngl)
+            p = m.poin_in_bdy_edge[ie, ig]; push!(xs, m.x[p]); push!(ys, m.y[p])
+        end
+        fit = _fit_circle_mpi(xs, ys, nothing)
+        @test fit !== nothing
+        c, resid = fit
+        @test c.xc ≈ XC atol = 1.0e-12
+        @test c.yc ≈ YC atol = 1.0e-12
+        @test c.r  ≈ R  atol = 1.0e-12
+        @test resid < 1.0e-12
+
+        # A straight boundary is not a circle: the fit must say so rather than
+        # return a circle of enormous radius and deform the wall onto it.
+        @test _fit_circle_mpi([0.0, 1.0, 2.0, 3.0], [0.0, 0.0, 0.0, 0.0], nothing) === nothing
+        @test _fit_circle_mpi([0.0, 1.0], [0.0, 1.0], nothing) === nothing      # too few
+
+        # A square is not a circle either: the fit succeeds but the residual is
+        # O(1) and _resolve_shape rejects it.
+        sq = _fit_circle_mpi([0.0,1.0,1.0,0.0,0.5], [0.0,0.0,1.0,1.0,0.0], nothing)
+        @test sq === nothing || sq[2] > 1.0e-6
+        @test _resolve_shape("sq", :circle, [0.0,1.0,1.0,0.0,0.5], [0.0,0.0,1.0,1.0,0.0],
+                             nothing, 0, true) === nothing
+    end
+
+    @testset "explicit shape spec" begin
+        m, l = build_annulus(4, 2, 16)
+        curve!(m, l; shape = (:circle, XC, YC, R))
+        for ie = 1:m.nedges_bdy, ig = 1:m.ngl
+            p = m.poin_in_bdy_edge[ie, ig]
+            @test hypot(m.x[p] - XC, m.y[p] - YC) ≈ R atol = 1.0e-14
+        end
+        @test_throws ErrorException curve!(build_annulus(4, 2, 8)...; shape = :ellipse)
+
+        # A deck may name the gmsh group with a Symbol just as well as a String.
+        m2, l2 = build_annulus(4, 2, 16)
+        snap_nodes_to_exact_geometry!(m2, l2,
+            Dict{Symbol,Any}(:exact_geometry => Dict(:circle => (:circle, XC, YC, R))), m2.SD)
+        @test m2.x == m.x && m2.y == m.y
+    end
+
+    @testset "no-op when nothing is asked for" begin
+        m, l = build_annulus(4, 2, 16)
+        x0, y0 = copy(m.x), copy(m.y)
+        snap_nodes_to_exact_geometry!(m, l, Dict{Symbol,Any}(), m.SD)
+        @test m.x == x0 && m.y == y0
+        # a tag no boundary carries is reported, not applied
+        snap_nodes_to_exact_geometry!(m, l,
+            Dict{Symbol,Any}(:exact_geometry => Dict("typo" => :circle)), m.SD)
+        @test m.x == x0 && m.y == y0
+        # nop = 1: no high-order nodes exist, so there is nothing to move
+        m1, l1 = build_annulus(1, 2, 16)
+        z0, w0 = copy(m1.x), copy(m1.y)
+        curve!(m1, l1)
+        @test m1.x == z0 && m1.y == w0
+    end
+
+    @testset "snapped grid" begin
+        N, nr, nt = 4, 4, 16
+        mesh, lgl = build_annulus(N, nr, nt)
+        D  = lagrange_nodal_derivative_matrix(lgl.ξ)
+        x0, y0 = copy(mesh.x), copy(mesh.y)
+        dmi0 = dmi_residual(mesh, D)
+        curve!(mesh, lgl)
+
+        @testset "boundary nodes land on the circle" begin
+            off_before = maximum(abs(hypot(x0[mesh.poin_in_bdy_edge[ie,k]] - XC,
+                                           y0[mesh.poin_in_bdy_edge[ie,k]] - YC) - R)
+                                 for ie = 1:mesh.nedges_bdy, k = 1:mesh.ngl)
+            off_after  = maximum(abs(hypot(mesh.x[mesh.poin_in_bdy_edge[ie,k]] - XC,
+                                           mesh.y[mesh.poin_in_bdy_edge[ie,k]] - YC) - R)
+                                 for ie = 1:mesh.nedges_bdy, k = 1:mesh.ngl)
+            @test off_before > 1.0e-3            # the straight-sided defect is real
+            @test off_after  < 1.0e-12
+        end
+
+        @testset "grid stays conforming" begin
+            # (a) an element that does not touch the circle keeps every node.
+            for iel = 1:mesh.nelem
+                iel in mesh.bdy_edge_in_elem && continue
+                for j = 1:mesh.ngl, i = 1:mesh.ngl
+                    p = mesh.connijk[iel, i, j]
+                    @test mesh.x[p] == x0[p]
+                    @test mesh.y[p] == y0[p]
+                end
+            end
+            # (b) the linear vertices — the element corners — never move, which
+            #     is what kills the Gordon-Hall corner terms and makes (a) hold.
+            for iel = 1:mesh.nelem, i in (1, mesh.ngl), j in (1, mesh.ngl)
+                p = mesh.connijk[iel, i, j]
+                @test mesh.x[p] == x0[p]
+                @test mesh.y[p] == y0[p]
+            end
+            # (c) nothing moved outside the one element layer on the boundary.
+            for p = 1:mesh.npoin
+                (mesh.x[p] == x0[p] && mesh.y[p] == y0[p]) && continue
+                @test hypot(x0[p] - XC, y0[p] - YC) <= R + (0.6 - R)/nr + 1.0e-12
+            end
+        end
+
+        @testset "no element folds" begin
+            for iel = 1:mesh.nelem
+                J, _, _ = element_metrics(mesh, iel, D)
+                @test minimum(J) > 0.0
+            end
+        end
+
+        @testset "discrete metric identities (Kopriva Thm 3)" begin
+            @test dmi0 < 1.0e-12
+            @test dmi_residual(mesh, D) < 1.0e-12
+        end
+    end
+
+    @testset "a fold is caught, not shipped" begin
+        # One azimuthal element spanning 120° against a radial thickness far
+        # smaller than the arc's sagitta: the blend has to turn the element
+        # inside out, and the validity check must say so.
+        @test_throws ErrorException begin
+            m, l = build_annulus(4, 1, 3; Rout = R + 0.002)
+            curve!(m, l)
+        end
+    end
+
+    @testset "boundary geometry converges at the isoparametric rate" begin
+        # Straight-sided is O(h²) whatever N is — the defect. Curved is at least
+        # O(h^{N+1}); for a circle sampled radially it comes out one order
+        # better still, so the assertion is >= N+1 with a little slack.
+        for N in (3, 4)
+            es = [boundary_error(N, nt; curved = false) for nt in (16, 32)]
+            ec = [boundary_error(N, nt; curved = true)  for nt in (16, 32)]
+            @test log2(es[1]/es[2]) ≈ 2.0 atol = 0.1          # stuck at 2nd order
+            @test log2(ec[1]/ec[2]) >= N + 0.8                # isoparametric
+            @test ec[2] < es[2]/1.0e2                         # and far smaller
+        end
+    end
+
+    @testset "curved-edge surface metrics" begin
+        # The Jef / normal formula that build_metric_terms!(…, NSD_2D) now uses.
+        tangent_metrics(m, l, ie) = begin
+            D = lagrange_nodal_derivative_matrix(l.ξ)
+            ngl = m.ngl
+            Jef = zeros(ngl); nx = zeros(ngl); ny = zeros(ngl)
+            for k = 1:ngl
+                tx = ty = 0.0
+                for i = 1:ngl
+                    p = m.poin_in_bdy_edge[ie, i]
+                    tx += D[k,i]*m.x[p]; ty += D[k,i]*m.y[p]
+                end
+                Jef[k] = hypot(tx, ty); nx[k] = ty/Jef[k]; ny[k] = -tx/Jef[k]
+            end
+            return Jef, nx, ny
+        end
+
+        # (a) On a STRAIGHT edge it must reproduce the chord/2 and the two-point
+        #     normal it replaces — this is what makes the change inert for every
+        #     existing case.
+        m, l = build_annulus(4, 2, 16)
+        for ie = 1:m.nedges_bdy
+            Jef, nx, ny = tangent_metrics(m, l, ie)
+            p1 = m.poin_in_bdy_edge[ie, 1]; p2 = m.poin_in_bdy_edge[ie, m.ngl]
+            chord = hypot(m.x[p1] - m.x[p2], m.y[p1] - m.y[p2])
+            @test all(j -> isapprox(Jef[j], chord/2; atol = 1.0e-12), 1:m.ngl)
+            dx = m.x[p2] - m.x[p1]; dy = m.y[p2] - m.y[p1]
+            for k = 1:m.ngl
+                @test nx[k] ≈  dy/chord atol = 1.0e-12
+                @test ny[k] ≈ -dx/chord atol = 1.0e-12
+            end
+        end
+
+        # (b) On the CURVED edge the normal must be the exact circle normal, and
+        #     Jef the exact arc |dX/dξ| = R·dθ/dξ. The two-point difference that
+        #     this replaces is only O(h) accurate, which is asserted too — it is
+        #     the reason the surface metrics had to change with the grid.
+        mc, lc = build_annulus(4, 2, 16)
+        curve!(mc, lc)
+        worst_exact = 0.0; worst_2pt = 0.0
+        for ie = 1:mc.nedges_bdy
+            Jef, nx, ny = tangent_metrics(mc, lc, ie)
+            for k = 1:mc.ngl
+                p  = mc.poin_in_bdy_edge[ie, k]
+                ex = (mc.x[p] - XC)/R; ey = (mc.y[p] - YC)/R      # exact unit normal
+                worst_exact = max(worst_exact, min(hypot(nx[k]-ex, ny[k]-ey),
+                                                   hypot(nx[k]+ex, ny[k]+ey)))
+                q  = mc.poin_in_bdy_edge[ie, k < mc.ngl ? k+1 : k-1]
+                dx = mc.x[p] - mc.x[q]; dy = mc.y[p] - mc.y[q]; d = hypot(dx, dy)
+                worst_2pt = max(worst_2pt, min(hypot(dy/d - ex, -dx/d - ey),
+                                               hypot(dy/d + ex, -dx/d + ey)))
+            end
+            # Jef is |dX/dξ|, and radial projection does NOT make θ linear in
+            # ξ, so it varies along the arc by a few percent — which is the
+            # whole point: the chord/2 it replaces was constant. What must be
+            # exact is the quantity Jef exists to produce, the arc length
+            # ∫|dX/dξ|dξ collocated on the LGL nodes, against R·Δθ.
+            p1 = mc.poin_in_bdy_edge[ie, 1]; p2 = mc.poin_in_bdy_edge[ie, mc.ngl]
+            θ1 = atan(mc.y[p1] - YC, mc.x[p1] - XC)
+            θ2 = atan(mc.y[p2] - YC, mc.x[p2] - XC)
+            Δθ = abs(rem(θ2 - θ1, 2pi, RoundNearest))
+            @test sum(lgl_weights(mc.nop) .* Jef) ≈ R*Δθ rtol = 1.0e-6
+            @test !all(j -> isapprox(Jef[j], Jef[1]; rtol = 1.0e-3), 1:mc.ngl)
+            @test all(j -> isapprox(Jef[j], R*Δθ/2; rtol = 0.05), 1:mc.ngl)
+        end
+        @test worst_exact < 1.0e-4          # tangent of the isoparametric edge
+        @test worst_2pt   > 1.0e-2          # the two-point normal it replaces
+        @test worst_2pt   > 50*worst_exact
+    end
+end

--- a/tools/pick_nranks.jl
+++ b/tools/pick_nranks.jl
@@ -1,0 +1,312 @@
+#!/usr/bin/env julia
+#
+# pick_nranks.jl -- choose the MPI rank count for a Jexpresso run that uses
+#                   :lxy_partition => true (column decomposition).
+#
+#   julia tools/pick_nranks.jl <nelemx> <nelemy> <nelemz> <nop> <max_cores> [Lx] [Ly]
+#
+#   e.g.  julia tools/pick_nranks.jl 128 128 120 4 2048
+#         julia tools/pick_nranks.jl  16  16 125 4  256
+#
+# WHY THIS EXISTS
+# ---------------
+# With :lxy_partition the mesh is cut into VERTICAL COLUMNS: z is never
+# partitioned, so the usable parallelism is bounded by nelemx*nelemy, and the
+# split _compute_xy_partition picks is aspect-ratio aware. That combination
+# makes the safe rank counts non-obvious: asking for more ranks than the chosen
+# nx*ny grid can fill leaves ranks owning ZERO elements, which is fatal
+# downstream (it shows up as "Min elements: 0" in the Load Balance Analysis
+# block, then a crash after the high-order node phase).
+#
+# Rather than approximate that, this script REPLICATES _compute_xy_partition
+# (src/kernel/mesh/mesh.jl) exactly -- including the centroid-span denominator
+# and the clamp -- and reports what each candidate rank count would actually
+# produce.
+#
+# THE CLOSED FORM, for the common square case (nelemx == nelemy == N):
+#
+#     use nparts = k^2  where k divides N
+#
+#   and pick the largest such k satisfying BOTH
+#       k^2 <= max_cores                       (your allocation)
+#       total_gridpoints / k^2 >= pts_target   (enough work per rank)
+#
+# Everything else here is that rule, generalised and checked against the real
+# partitioner.
+
+# ---- exact replication of _compute_xy_partition (mesh.jl:1720) -------------
+function partition_counts(nelemx, nelemy, nparts, Lx, Ly)
+    cx = [(i + 0.5) * Lx / nelemx for i in 0:nelemx-1]
+    cy = [(j + 0.5) * Ly / nelemy for j in 0:nelemy-1]
+    lx = maximum(cx) - minimum(cx) + 1e-10
+    ly = maximum(cy) - minimum(cy) + 1e-10
+
+    divisors  = [d for d in 1:nparts if nparts % d == 0]
+    target_nx = sqrt(nparts * lx / ly)
+    nx = divisors[argmin(abs.(divisors .- target_nx))]
+    ny = nparts ÷ nx
+
+    xmin, ymin = minimum(cx), minimum(cy)
+    counts = zeros(Int, nparts)
+    for x in cx, y in cy
+        xi = clamp(floor(Int, (x - xmin) / lx * nx), 0, nx - 1)
+        yi = clamp(floor(Int, (y - ymin) / ly * ny), 0, ny - 1)
+        counts[xi * ny + yi + 1] += 1
+    end
+    return nx, ny, counts
+end
+
+# ──────────────────────────────────────────────────────────────────────────
+# p4est / space-filling-curve mode.
+#
+#   julia tools/pick_nranks.jl --p4est <nelem> <nop> <max_cores>
+#
+# Completely different constraint structure from the column mode below, and
+# the difference is worth stating because it inverts the usual advice.
+#
+# The column partitioner bins cells by centroid into an nx x ny grid, so the
+# rank count must factor to match the mesh or ranks come out EMPTY and the run
+# dies. p4est has no such requirement: it cuts the space-filling curve into
+# nparts contiguous chunks of floor(N/P) or ceil(N/P) leaves. Any count works,
+# and the element imbalance is at most ONE cell -- negligible except when the
+# chunks themselves get tiny. Divisibility buys essentially nothing here; do
+# not chase it.
+#
+# What does bind:
+#
+#   work per rank      A rank holding too few elements spends its time in halo
+#                      exchange rather than in the RHS. This is the real cap on
+#                      useful parallelism.
+#
+#   surface-to-volume  A Morton/Hilbert chunk of e elements is compact, roughly
+#                      a cube, so its halo scales as e^(2/3) and halo per
+#                      element as ~6/e^(1/3). Halving e per rank multiplies
+#                      communication per unit work by 2^(1/3).
+#
+# Gridpoints are estimated as nelem * nop^3: in a structured mesh each element
+# contributes nop^3 unique nodes, the rest being shared with its neighbours.
+# The estimate is exact only in the limit of many elements per direction, and
+# it always UNDERSTATES, because the outermost layer of nodes is shared with
+# nothing. Measured against exact counts at nop=4:
+#
+#     128x128x120   125.8M vs 126.6M    -0.6%
+#      32x32x30      1.97M vs  2.01M    -2.4%
+#      16x16x15       246k vs   258k    -4.6%
+#       8x2x60         61k vs    72k   -14.2%
+#
+# Thin or small meshes are where it drifts, since the boundary is a larger
+# fraction of them. Erring low means the recommendation is conservative -- it
+# credits each rank with slightly less work than it really has, and so asks for
+# slightly fewer ranks. If your mesh is small or has a short direction, pass
+# the exact gridpoint count via the column mode instead, which computes it.
+function p4est_mode(nelem, nop, maxc)
+    ptsmin = parse(Int, get(ENV, "JEXPRESSO_PTS_PER_RANK", "50000"))
+    dof    = nelem * nop^3
+    println("partitioning  : p4est, space-filling curve (any rank count is valid)")
+    println("elements      : $(nelem)   nop=$(nop)  ->  ~$(dof) gridpoints")
+    println("budget        : $(maxc) cores;  target >= $(ptsmin) gridpoints/rank\n")
+
+    # Largest rank count that still keeps each rank above the work floor...
+    rcap = max(1, min(maxc, dof ÷ max(ptsmin, 1)))
+    # ...then round DOWN to a multiple of 8. The unrounded cap is usually an
+    # awkward number (39, 157, 613): SLURM allocates whole cores, so 39 ranks
+    # leaves most of a 64-core node idle and bills you for it either way. A
+    # multiple of 8 packs into any common node width, and giving up a few ranks
+    # of the cap costs nothing -- the work floor is a soft threshold, not a
+    # cliff. p4est is indifferent to the exact number, so this is free.
+    rec = rcap >= 8 ? (rcap ÷ 8) * 8 : rcap
+
+    cands = Int[]
+    r = 1
+    while r <= maxc
+        push!(cands, r); r *= 2
+    end
+    rec  in cands || push!(cands, rec)
+    rcap in cands || push!(cands, rcap)
+    maxc in cands || push!(cands, maxc)
+    sort!(unique!(cands))
+
+    println(rpad("ranks",8), rpad("elem/rank",12), rpad("dof/rank",12),
+            rpad("imbalance",11), rpad("halo/elem",11), "note")
+    for n in cands
+        n > maxc && continue
+        lo, hi = fld(nelem, n), cld(nelem, n)
+        lo == 0 && continue
+        imb  = hi / (nelem / n)
+        halo = 6 / cbrt(nelem / n)
+        note = n == rec ? "  <== RECOMMENDED" :
+               (dof / n < ptsmin ? "  (thin: comms-bound)" : "")
+        println(rpad(n,8), rpad("$(lo)-$(hi)",12), rpad(round(Int, dof/n),12),
+                rpad(round(imb, digits=4),11), rpad(round(halo, digits=2),11), note)
+    end
+
+    lo, hi = fld(nelem, rec), cld(nelem, rec)
+    println("\nRECOMMENDED: $(rec) ranks")
+    println("   $(lo)-$(hi) elements/rank, ~$(round(Int, dof/rec)) gridpoints/rank,")
+    println("   halo/elem ~$(round(6/cbrt(nelem/rec), digits=2)), imbalance $(round(hi/(nelem/rec), digits=4))x")
+    rec == rcap || println("   ($(rcap) is the raw cap at this work floor; rounded down to pack into nodes)")
+    nodes = cld(rec, 64)
+    println("\n  #SBATCH --nodes=$(nodes)")
+    println("  #SBATCH --ntasks-per-node=$(cld(rec, nodes))")
+    println("\nAny other count up to $(maxc) also runs -- p4est does not care about")
+    println("divisibility. Going above $(rcap) keeps working but each rank drops")
+    println("below $(ptsmin) gridpoints, so more of its time goes to halo exchange")
+    println("than to the RHS. Raise the floor with JEXPRESSO_PTS_PER_RANK to be")
+    println("more conservative, or lower it to trade efficiency for wall-clock.")
+    return nothing
+end
+
+
+#-----------------------------------------------------------------------------
+# --columns : rank counts that keep vertical columns on one rank
+#
+# HEVI's implicit stage is a column solve, and it is cheapest when a column
+# lives entirely on one rank. Under p4est that is not automatic. Leaves are
+# ordered by (tree, Morton-within-tree) and the partition cuts contiguous
+# ranges of that order, so:
+#
+#   * a partial tree is a Morton sub-cube -- it spans only part of the tree's
+#     vertical extent, so column locality does NOT survive a cut inside a tree;
+#   * whole trees do keep their columns, so if the rank count divides the
+#     number of TREE COLUMNS (nelemx * nelemy of the COARSE mesh) and each rank
+#     gets a whole number of them, every column is rank-local.
+#
+# The refinement level does not change this: refining multiplies the leaves per
+# tree, not the tree layout. What it does change is how many elements a rank
+# ends up with, which is the other half of the trade -- one tree column of a
+# 16x16x15 coarse mesh refined three times is 7680 elements, which is a lot to
+# put on one rank.
+#
+# This is guidance, not a guarantee: the coarse mesh must also be ordered
+# column-major (tools/reorder_msh_columns.jl) for tree columns to be
+# contiguous in the first place. The ground truth is the split percentage the
+# HEVI setup prints at the top of a run -- if that says 0%, the partition is
+# column-local whatever this tool predicted.
+#-----------------------------------------------------------------------------
+function columns_mode(cx, cy, cz, lvl, maxc)
+    ncol   = cx * cy
+    per    = 2^lvl
+    trees  = cx * cy * cz
+    leaves = trees * per^3
+    println("coarse mesh   : $(cx) x $(cy) x $(cz) trees  ($(trees) trees)")
+    println("refine level  : $(lvl)  ->  $(cx*per) x $(cy*per) x $(cz*per) elements ",
+            "($(leaves) leaves)")
+    println("tree columns  : $(ncol)")
+    println("budget        : $(maxc) ranks\n")
+    println("  ranks   tree cols/rank   elements/rank   note")
+    any = false
+    for n = 1:maxc
+        ncol % n == 0 || continue
+        any = true
+        cpr = ncol ÷ n
+        epr = leaves ÷ n
+        note = epr > 4000 ? "heavy: consider a finer coarse mesh" :
+               epr < 200  ? "light: halo may dominate the RHS"    : ""
+        println(lpad(n, 7), lpad(cpr, 16), lpad(epr, 16), "   ", note)
+    end
+    any || println("  none -- $(ncol) tree columns has no divisor <= $(maxc)")
+    println()
+    println("Any rank count NOT in this list still runs: columns that straddle a rank")
+    println("boundary are gathered onto an owner for the solve and scattered back. The")
+    println("cost is proportional to how many straddle, which the run reports at setup.")
+    return nothing
+end
+
+function main()
+    if "--columns" in ARGS
+        a = filter(x -> x != "--columns", ARGS)
+        if length(a) < 5
+            println("usage: julia tools/pick_nranks.jl --columns <coarse_nx> <coarse_ny> ",
+                    "<coarse_nz> <refine_lvl> <max_ranks>")
+            return
+        end
+        return columns_mode(parse.(Int, a[1:5])...)
+    end
+    if "--p4est" in ARGS
+        a = filter(x -> x != "--p4est", ARGS)
+        if length(a) < 3
+            println("usage: julia tools/pick_nranks.jl --p4est <nelem> <nop> <max_cores>")
+            return
+        end
+        return p4est_mode(parse.(Int, a[1:3])...)
+    end
+    if length(ARGS) < 5
+        println("usage: julia tools/pick_nranks.jl <nelemx> <nelemy> <nelemz> <nop> <max_cores> [Lx] [Ly]")
+        return
+    end
+    nelemx, nelemy, nelemz, nop, maxc = parse.(Int, ARGS[1:5])
+    Lx = length(ARGS) >= 6 ? parse(Float64, ARGS[6]) : Float64(nelemx)
+    Ly = length(ARGS) >= 7 ? parse(Float64, ARGS[7]) : Float64(nelemy)
+
+    # Target gridpoints per rank. Below ~20k a spectral-element CPU rank spends
+    # more time in halo exchange than in the RHS; 50k keeps it comfortably
+    # compute-bound. Override with JEXPRESSO_PTS_PER_RANK.
+    pts_target = parse(Int, get(ENV, "JEXPRESSO_PTS_PER_RANK", "50000"))
+
+    totpts = (nelemx*nop + 1) * (nelemy*nop + 1) * (nelemz*nop + 1)
+    println("mesh      : $(nelemx) x $(nelemy) x $(nelemz) elements, nop=$(nop)")
+    println("domain    : Lx/Ly = $(round(Lx/Ly, digits=3))")
+    println("gridpoints: $(totpts)")
+    println("budget    : $(maxc) cores;  target >= $(pts_target) points/rank\n")
+
+    rows = NamedTuple[]
+    for n in 1:maxc
+        nx, ny, c = partition_counts(nelemx, nelemy, n, Lx, Ly)
+        mn, mx = minimum(c), maximum(c)
+        mn == 0 && continue                       # empty rank => crash
+        push!(rows, (n=n, nx=nx, ny=ny, mn=mn, mx=mx,
+                     imb = mx/(sum(c)/n),
+                     pts = totpts/n,
+                     halo = 2*(nx/nelemx + ny/nelemy)))
+    end
+
+    # Valid = no empty ranks AND every rank owning the SAME number of columns.
+    # Anything else wastes cores waiting on the heaviest rank at every halo
+    # exchange, and the near-miss counts (nparts prime, or not factorable to
+    # match the element grid) are never worth the extra cores.
+    ok = filter(r -> r.mn == r.mx, rows)
+    best = filter(r -> r.pts >= pts_target, ok)
+    rec  = isempty(best) ? (isempty(ok) ? nothing : ok[1]) : best[end]
+
+    println("COLUMN HEADINGS")
+    println("  rank grid   : how the RANKS are arranged (nx x ny), NOT your element grid")
+    println("  block       : element columns each rank owns, as (nelemx/nx) x (nelemy/ny)")
+    println("  cols/rank   : total columns per rank = the two block numbers multiplied")
+    println("  halo/elem   : halo faces per owned element -- pure communication overhead\n")
+    println(rpad("ranks",7), rpad("rank grid",12), rpad("block",10), rpad("cols/rank",11),
+            rpad("pts/rank",11), rpad("halo/elem",11), "note")
+    for r in ok
+        note = rec !== nothing && r.n == rec.n ? "  <== RECOMMENDED" :
+               (r.pts < pts_target ? "  (thin: comms-bound)" : "")
+        println(rpad(r.n,7), rpad("$(r.nx) x $(r.ny)",12),
+                rpad("$(nelemx÷r.nx) x $(nelemy÷r.ny)",10),
+                rpad(r.mn == r.mx ? "$(r.mn)" : "$(r.mn)-$(r.mx)", 11),
+                rpad(round(Int, r.pts), 11),
+                rpad(round(r.halo, digits=2), 11), note)
+    end
+
+    if rec === nothing
+        println("\nNo valid rank count found at or below $(maxc).")
+    else
+        println("\nRECOMMENDED: $(rec.n) ranks")
+        println("   ranks arranged $(rec.nx) x $(rec.ny) over your $(nelemx) x $(nelemy) element columns,")
+        println("   so each rank owns a $(nelemx÷rec.nx) x $(nelemy÷rec.ny) block of columns " *
+                "($(rec.mn) columns, full height),")
+        println("   $(round(Int, rec.pts)) gridpoints/rank, halo/elem $(round(rec.halo, digits=2)).")
+        if rec.nx != rec.ny
+            println("\n   NOTE: $(rec.nx) x $(rec.ny) is not square because $(rec.n) is not a perfect")
+            println("   square, so the blocks are elongated and the halo is larger than it")
+            println("   needs to be. If you would rather have square blocks, use the largest")
+            println("   k*k below with k dividing $(nelemx).")
+        end
+        nodes = cld(rec.n, 64)
+        println("\n  #SBATCH --nodes=$(nodes)")
+        println("  #SBATCH --ntasks-per-node=$(cld(rec.n, nodes))")
+        println("\n  (64 ranks/node keeps per-node memory low during the mesh")
+        println("   broadcast, which is the peak of the whole run.)")
+    end
+    println("\nRank counts NOT listed above would leave some ranks with zero")
+    println("elements, or badly imbalanced. Do not use them.")
+end
+
+main()

--- a/tools/syntax_check.jl
+++ b/tools/syntax_check.jl
@@ -1,0 +1,99 @@
+#!/usr/bin/env julia
+#
+# syntax_check.jl -- parse AND lower every .jl file, without loading the package.
+#
+# WHY LOWERING AND NOT JUST PARSING
+# ---------------------------------
+# `Meta.parse` is not enough. A stray `$` outside a string parses cleanly -- it
+# becomes Expr(:$, ...) -- and only fails when the expression is LOWERED:
+#
+#     julia> Meta.parse("f(m) = g((\$m + 4) * 2)")     # no error
+#     julia> Meta.lower(Main, ans)
+#     :($(Expr(:error, "\"\$\" expression outside quote")))
+#
+# That exact typo shipped in krylov.jl and broke precompilation on every rank
+# of a 256-rank job, after a 133-second precompile, for a one-character error a
+# check like this catches in under a second. A parse-only check reported the
+# file as fine.
+#
+# This is deliberately NOT `using Jexpresso`: it needs no instantiated
+# environment and no MPI, so it runs anywhere, including a laptop or a login
+# node with nothing set up.
+#
+#   julia tools/syntax_check.jl [paths...]      (default: src test problems tools)
+#
+# Exit status is 1 if anything fails, so it can gate a commit or a job script.
+
+const ROOTS = isempty(ARGS) ? ["src", "test", "problems", "tools"] : ARGS
+
+# Some files in this repo are not Julia at all -- src/arrays/Maps.jl is a saved
+# GitHub HTML page, committed long ago and included by nothing. Reporting it as
+# a syntax failure would make this check always exit 1 and therefore useless as
+# a gate, so it is called out separately instead.
+isnotjulia(src) = occursin(r"^\s*<(!DOCTYPE|html)"i, first(src, 200))
+
+function check(path)
+    src = read(path, String)
+    isnotjulia(src) && return :notjulia
+    pos, n = 1, 0
+    while pos <= lastindex(src)
+        local ex
+        try
+            ex, pos = Meta.parse(src, pos; raise = true)
+        catch e
+            return "parse: " * sprint(showerror, e)
+        end
+        ex === nothing && break
+        n += 1
+        # Lowering expands macros, so it THROWS on any macro this process has
+        # not loaded (@add_arg_table, @kernel, ...). That is not a defect in the
+        # file -- skip it. Only a returned Expr(:error) is a real syntax fault;
+        # that is the form `$` outside a quote takes, which is the case this
+        # whole check exists for.
+        lo = try
+            Meta.lower(Main, ex)
+        catch
+            continue
+        end
+        if lo isa Expr && lo.head === :error
+            return "lower: " * string(lo.args[1]) * "  (top-level expression $n)"
+        end
+    end
+    return nothing
+end
+
+bad = Tuple{String,String}[]
+skipped = String[]
+nfiles = 0
+for root in ROOTS
+    if !isdir(root)
+        if isfile(root) && endswith(root, ".jl")
+            global nfiles += 1
+            e = check(root)
+            e === nothing || (e === :notjulia ? push!(skipped, root) : push!(bad, (root, e)))
+        end
+        continue
+    end
+    for (dir, _, files) in walkdir(root), f in files
+        endswith(f, ".jl") || continue
+        p = joinpath(dir, f)
+        global nfiles += 1
+        e = check(p)
+        e === nothing && continue
+        e === :notjulia ? push!(skipped, p) : push!(bad, (p, e))
+    end
+end
+for p in skipped
+    println("syntax_check: SKIP $p (not a Julia source file)")
+end
+
+if isempty(bad)
+    println("syntax_check: $nfiles files OK")
+    exit(0)
+else
+    for (p, e) in bad
+        println("syntax_check: FAIL $p\n    $e")
+    end
+    println("\nsyntax_check: $(length(bad)) of $nfiles files failed")
+    exit(1)
+end


### PR DESCRIPTION
* Exact geometry (for circles only for now)
- CompEuler/shock_circle

Old: linear sides
<img width="399" height="386" alt="image" src="https://github.com/user-attachments/assets/6affb8ad-c532-4d10-a017-d21722c05969" />
New: exact along circle
<img width="376" height="388" alt="image" src="https://github.com/user-attachments/assets/44970436-2ed9-44a7-a117-79031b7f5c5d" />
