### PR TITLE
Add :AD to the mesh/SEM cache fingerprint

### DIFF
--- a/src/kernel/coupling/couplingStructs.jl
+++ b/src/kernel/coupling/couplingStructs.jl
@@ -182,6 +182,10 @@ end
 # spuriously invalidate the cache.
 const _CACHE_FINGERPRINT_KEYS = (
     :nop, :nsd, :backend,
+    # The discretization determines the numbering itself — ContGal shares
+    # interface nodes, DiscGal duplicates them — so a cached mesh or SEM
+    # file is only valid for the :AD it was built under.
+    :AD,
     :lexact_integration, :interpolation_nodes, :quadrature_nodes,
     :llump, :ldss_laplace, :ldss_differentiation,
     :llaguerre_1d_right, :llaguerre_1d_left,


### PR DESCRIPTION
The cache fingerprint governs both the mesh cache and the SEM preprocess cache, and the discretization determines the numbering itself: ContGal shares interface nodes, DiscGal duplicates them, so npoin and connijk differ for otherwise identical inputs. Without :AD in the fingerprint, switching the discretization inside one case directory can load a cache built under the other numbering — neither cache filename carries a discretization marker.

This is a latent correctness bug independent of the DG work: it affects any user switching :AD in place, and bites hardest on exactly the A/B comparisons used to show a change is behaviour-neutral.

One commit, keys-only — `:AD` added to `_CACHE_FINGERPRINT_KEYS` with a rationale comment in the annotated-key style. No schema bump needed: the key-list length comparison in `_cache_fingerprint_matches` invalidates existing caches once by itself. Behaviour-neutral for numerics; `AdvDiff/2d` (ContGal) regenerates once, then cache-hits on the second run.

This is the standalone fix from our August thread (your item 6). The CIdescription.md key-name note from the same thread turned out to be already resolved by the CI rework, so it's not included.